### PR TITLE
Sort txf list

### DIFF
--- a/help/C/Help_txf-categories.xml
+++ b/help/C/Help_txf-categories.xml
@@ -51,345 +51,6 @@
 <row><entry><para><emphasis>  F1040 \ </emphasis>N269</para><para>Taxable fringe benefits</para></entry>
 <entry>Fringe benefits you receive in connection with the performance of your services are included in your gross income as compensation. Examples: Accident or Health Plan, Educational Assistance, Group-Term Life Insurance, Transportation (company car).</entry>
 </row>
-<row><entry><para><emphasis>Help F1099-G \ </emphasis>H634</para><para>Form 1099-G - certain Government payments</para></entry>
-<entry>Form 1099-G is used to report certain government payments from federal, state, or local governments.</entry>
-</row>
-<row><entry><para><emphasis>  F1099-G \ </emphasis>N672</para><para>Qualified state tuition earnings</para></entry>
-<entry>Qualified state tuition program earnings you received this year.</entry>
-</row>
-<row><entry><para><emphasis>  F1099-G \ </emphasis>N260</para><para>State and local tax refunds</para></entry>
-<entry>Refund of state or local income tax refund (or credit or offset) which you deducted or took a credit for in an earlier year. You should receive a statement, Form 1099-G. Not reportable if you didn&rsquo;t itemize last year.</entry>
-</row>
-<row><entry><para><emphasis>  F1099-G \ </emphasis>N479</para><para>Unemployment compensation</para></entry>
-<entry>Total unemployment compensation paid to you this year. Reported on Form 1099-G.</entry>
-</row>
-<row><entry><para><emphasis>Help F1099-MISC \ </emphasis>H553</para><para>Form 1099-MISC - MISCellaneous income</para></entry>
-<entry>Form 1099-MISC is used to report miscellaneous income received and direct sales of consumer goods for resale.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N562</para><para>Crop insurance proceeds</para></entry>
-<entry>The amount of crop insurance proceeds as the result of crop damage.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N559</para><para>Fishing boat proceeds</para></entry>
-<entry>Your share of all proceeds from the sale of a catch or the fair market value of a distribution in kind that you received as a crew member of a fishing boat.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N560</para><para>Medical/health payments</para></entry>
-<entry>The amount of payments received as a physician or other supplier or provider of medical or health care services. This includes payments made by medical and health care insurers under health, accident, and sickness insurance programs.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N561</para><para>Non employee compensation</para></entry>
-<entry>The amount of non-employee compensation received. This includes fees, commissions, prizes and awards for services performed, other forms of compensation for services you performed for a trade or business by which you are not employed.  Also include oil and gas payments for a working interest.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N557</para><para>Other income</para></entry>
-<entry>The amount of prizes and awards that are not for services performed. Included is the fair market value of merchandise won on game shows. Included is all punitive damages, any damages for nonphysical injuries or sickness, and any other taxable damages, Deceased employee&rsquo;s wages paid to estate or beneficiary.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N259</para><para>Prizes and awards</para></entry>
-<entry>The amount of prizes and awards that are not for services performed. Included is the fair market value of merchandise won on game shows.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N555</para><para>Rents</para></entry>
-<entry>Amounts received for all types of rents, such as real estate rentals for office space, machine rentals, and pasture rentals.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N556</para><para>Royalties</para></entry>
-<entry>The gross royalty payments received from a publisher or literary agent.</entry>
-</row>
-<row><entry><para><emphasis>Help F1099=MSA \ </emphasis>H629</para><para>Form 1099-MSA Medical Savings Account</para></entry>
-<entry>Form 1099-MSA is used to report medical savings account distributions.</entry>
-</row>
-<row><entry><para><emphasis>  F1099-MSA \ </emphasis>N632</para><para>MSA earnings on excess contrib</para></entry>
-<entry>The earnings on any excess contributions you withdrew from an MSA by the due date of your income tax return. If you withdrew the excess, plus any earnings, by the due date of your income tax return, you must include the earnings in your income in the year you received the distribution even if you used it to pay qualified medical expenses.</entry>
-</row>
-<row><entry><para><emphasis>  F1099-MSA \ </emphasis>N631</para><para>MSA gross distribution</para></entry>
-<entry>The amount you received this year from a Medical Savings Account. The amount may have been a direct payment to the medical service provider or distributed to you.</entry>
-</row>
-<row><entry><para><emphasis>Help F1099-R \ </emphasis>H473</para><para>Form 1099-R - Retirement distributions</para></entry>
-<entry>Form 1099-R is used to report taxable and non-taxable retirement distributions from retirement, pension, profit-sharing, or annuity plans. Use a separate Form 1099-R for each payer.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-R \ </emphasis>N623</para><para>SIMPLE total gross distribution</para></entry>
-<entry>The gross amount of a distribution received from a qualified SIMPLE pension plan.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-R \ </emphasis>N624</para><para>SIMPLE total taxable distribution</para></entry>
-<entry>The taxable amount of a distribution received from a qualified SIMPLE plan. This amount may be subject to a federal penalty of up to 25%.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-R \ </emphasis>N477</para><para>Total IRA gross distribution</para></entry>
-<entry>The gross amount of a distribution from a qualified Individual Retirement Arrangement (IRA) plan.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-R \ </emphasis>N478</para><para>Total IRA taxable distribution</para></entry>
-<entry>The taxable amount of a distribution from a qualified Individual Retirement Arrangement (IRA) plan.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-R \ </emphasis>N475</para><para>Total pension gross distribution</para></entry>
-<entry>The gross amount of a distribution from a qualified pension or annuity plan. Note: IRA distributions are not included here.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-R \ </emphasis>N476</para><para>Total pension taxable distribution</para></entry>
-<entry>The taxable amount of a distribution from a qualified pension or annuity plan. Note: IRA distributions are not included here.</entry>
-</row>
-<row><entry><para><emphasis>Help F2106 \ </emphasis>H380</para><para>employee business expenses</para></entry>
-<entry>Form 2106 is used to deduct employee business expenses. You must file this form if you were reimbursed by your employer or claim job-related travel, transportation, meal, or entertainment expenses. Use a separate Form 2106 for your spouse&rsquo;s expenses.</entry>
-</row>
-<row><entry><para><emphasis>  F2106 \ </emphasis>N387</para><para>Reimb. business expenses (non-meal/ent.)</para></entry>
-<entry>Reimbursement for business expenses from your employer that is NOT included on your Form W-2. Note: meals and entertainment are NOT included here.</entry>
-</row>
-<row><entry><para><emphasis>  F2106 \ </emphasis>N388</para><para>Reimb. meal/entertainment expenses</para></entry>
-<entry>Reimbursement for meal and entertainment expenses from your employer that is NOT included on your Form W-2.</entry>
-</row>
-<row><entry><para><emphasis>Help F4137 \ </emphasis>H503</para><para>Form 4137 - tips not reported</para></entry>
-<entry>Form 4137 is used to compute social security and Medicare tax owed on tips you did not report to your employer.</entry>
-</row>
-<row><entry><para><emphasis>  F4137 \ </emphasis>N505</para><para>Total cash/tips not reported to employer</para></entry>
-<entry>The amount of tips you did not report to your employer.</entry>
-</row>
-<row><entry><para><emphasis>Help F4684 \ </emphasis>H412</para><para>Form 4684 - casualties and thefts</para></entry>
-<entry>Form 4684 is used to report gains and losses from casualties and thefts.</entry>
-</row>
-<row><entry><para><emphasis>  F4684 \ </emphasis>N416</para><para>FMV after casualty</para></entry>
-<entry>The fair market value (FMV) is the price at which the property would change hands between a willing buyer and seller, each having knowledge of the relevant facts. The FMV after a theft is zero if the property is not recovered. The FMV is generally determined by competent appraisal.</entry>
-</row>
-<row><entry><para><emphasis>  F4684 \ </emphasis>N415</para><para>FMV before casualty</para></entry>
-<entry>The fair market value (FMV) is the price at which the property would change hands between a willing buyer and seller, each having knowledge of the relevant facts. FMV is generally determined by competent appraisal.</entry>
-</row>
-<row><entry><para><emphasis>  F4684 \ </emphasis>N414</para><para>Insurance/reimbursement</para></entry>
-<entry>The amount of insurance or other reimbursement you received expect to receive.</entry>
-</row>
-<row><entry><para><emphasis>Help F4835 \ </emphasis>H569</para><para>Form 4835 - farm rental income</para></entry>
-<entry>Form 4835 is used to report farm rental income received as a share of crops or livestock produced by your tenant if you did not materially participate in the operation or management of the farm.  Use a different copy of Form 4835 for each farm rented.</entry>
-</row>
-<row><entry><para><emphasis>  F4835 \ </emphasis>N573</para><para>Agricultural program payments</para></entry>
-<entry>Government payments received for: price support payments, market gain from the repayment of a secured Commodity Credit Corporation (CCC) loan for less than the original loan amount, diversion payments, cost-share payments (sight drafts), payments in the form of materials (such as fertilizer or lime) or services (such as grading or building dams). Reported on Form 1099-G.</entry>
-</row>
-<row><entry><para><emphasis>  F4835 \ </emphasis>N575</para><para>CCC loans forfeited/repaid</para></entry>
-<entry>The full amount forfeited or repaid with certificates, even if you reported the loan proceeds as income.  See IRS Pub 225.</entry>
-</row>
-<row><entry><para><emphasis>  F4835 \ </emphasis>N574</para><para>CCC loans reported/election</para></entry>
-<entry>Generally, you do not report CCC loan proceeds as income. However, if you pledge part or all of your production to secure a CCC loan, you may elect to report the loan proceeds as income in the year you receive them, instead of the year you sell the crop.</entry>
-</row>
-<row><entry><para><emphasis>  F4835 \ </emphasis>N577</para><para>Crop insurance proceeds deferred</para></entry>
-<entry>If you use the cash method of accounting and receive crop insurance proceeds in the same tax year in which the crops are damaged, you can choose to postpone reporting the proceeds as income until the following tax year. A statement must also be attached to your return.  See IRS Pub 225.</entry>
-</row>
-<row><entry><para><emphasis>  F4835 \ </emphasis>N576</para><para>Crop insurance proceeds received</para></entry>
-<entry>You generally include crop insurance proceeds in the year you receive them. Treat as crop insurance proceeds the crop disaster payments you receive from the federal government.</entry>
-</row>
-<row><entry><para><emphasis>  F4835 \ </emphasis>N578</para><para>Other income</para></entry>
-<entry>Illegal Federal irrigation subsidies, bartering income, income from discharge of indebtedness, state gasoline or fuel tax refund, the gain or loss on the sale of commodity futures contracts, etc.</entry>
-</row>
-<row><entry><para><emphasis>  F4835 \ </emphasis>N571</para><para>Sale of livestock/produce</para></entry>
-<entry>Income you received from livestock, produce, grains, and other crops based on production. Under both the cash and the accrual methods of reporting, you must report livestock or crop share rentals received in the year you convert them into money or its equivalent.</entry>
-</row>
-<row><entry><para><emphasis>  F4835 \ </emphasis>N572</para><para>Total cooperative distributions</para></entry>
-<entry>Distributions received from a cooperative. This includes patronage dividends, non patronage distributions, per-unit retain allocations, and redemption of non qualified notices and per unit retain allocations. Reported on Form 1099-PATR.</entry>
-</row>
-<row><entry><para><emphasis>Help F6252 \ </emphasis>H427</para><para>Form 6252 - income from casual sales</para></entry>
-<entry>Form 6252 is used to report income from casual sales of real or personal property when you will receive any payments in a tax year after the year of sale (i.e., installment sale).</entry>
-</row>
-<row><entry><para><emphasis>  F6252 \ </emphasis>N429</para><para>Debt assumed by buyer</para></entry>
-<entry>Enter only mortgages or other debts the buyer assumed from the seller or took the property subject to. Do not include new mortgages the buyer gets from a bank, the seller, or other sources.</entry>
-</row>
-<row><entry><para><emphasis>  F6252 \ </emphasis>N431</para><para>Depreciation allowed</para></entry>
-<entry>Enter all depreciation or amortization you deducted or should have deducted from the date of purchase until the date of sale. Add any section 179 expense deduction.  Several other adjustments are allowed, See Form 6252 instructions.</entry>
-</row>
-<row><entry><para><emphasis>  F6252 \ </emphasis>N435</para><para>Payments received prior years</para></entry>
-<entry>Enter all money and the fair market value (FMV) of property you received before this tax year from the sale. Include allocable installment income and any other deemed payments from prior years. Do not include interest whether stated or unstated.</entry>
-</row>
-<row><entry><para><emphasis>  F6252 \ </emphasis>N434</para><para>Payments received this year</para></entry>
-<entry>Enter all money and the fair market value (FMV) of any property you received in this tax year. Include as payments any amount withheld to pay off a mortgage or other debt, such as broker and legal fees. Do not include interest whether stated or unstated.</entry>
-</row>
-<row><entry><para><emphasis>  F6252 \ </emphasis>N428</para><para>Selling price</para></entry>
-<entry>Enter the total of any money, face amount of the installment obligation, and the FMV of other property that you received or will receive in exchange for the property sold.</entry>
-</row>
-<row><entry><para><emphasis>Help F8815 \ </emphasis>H441</para><para>Form 8815 - EE U.S. savings bonds sold for education</para></entry>
-<entry>Form 8815 is used to compute the amount of interest you may exclude if you cashed series EE U.S. savings bonds this year that were issued after 1989 to pay for qualified higher education costs.</entry>
-</row>
-<row><entry><para><emphasis>  F8815 \ </emphasis>N444</para><para>EE US savings bonds proceeds</para></entry>
-<entry>Enter the total proceeds (principal and interest) from all series EE and I U.S. savings bonds issued after 1989 that you cashed during this tax year.</entry>
-</row>
-<row><entry><para><emphasis>  F8815 \ </emphasis>N443</para><para>Nontaxable education benefits</para></entry>
-<entry>Nontaxable educational benefits. These benefits include: Scholarship or fellowship grants excludable from income under section 117; Veterans&rsquo; educational assistance benefits; Employer-provided educational assistance benefits that are not included in box 1 of your W-2 form(s); Any other payments (but not gifts, bequests, or inheritances) for educational expenses that are exempt from income tax by any U.S. law. Do not include nontaxable educational benefits paid directly to, or by, the educational institution.</entry>
-</row>
-<row><entry><para><emphasis>  F8815 \ </emphasis>N445</para><para>Post-89 EE bond face value</para></entry>
-<entry>The face value of all post-1989 series EE bonds cashed this tax year.</entry>
-</row>
-<row><entry><para><emphasis>Help F8863 \ </emphasis>H639</para><para>Form 8863 - Hope and Lifetime Learning education credits</para></entry>
-<entry>Form 8863 is used to compute the Hope and Lifetime Learning education credits. IRS rules are stringent for these credits.  Refer to IRS Publication 970 for more information.</entry>
-</row>
-<row><entry><para><emphasis>  F8863 \ </emphasis>N637</para><para>Hope credit</para></entry>
-<entry>Expenses qualified for the Hope credit are amounts paid this tax year for tuition and fees required for the student&rsquo;s enrollment or attendance at an eligible educational institution.</entry>
-</row>
-<row><entry><para><emphasis>  F8863 \ </emphasis>N638</para><para>Lifetime learning credit</para></entry>
-<entry>Expenses qualified for the Lifetime Learning credit are amounts paid this tax year for tuition and fees required for the student&rsquo;s enrollment or attendance at an eligible educational institution.</entry>
-</row>
-<row><entry><para><emphasis>  Home Sale \ </emphasis>N392</para><para>Home Sale worksheets (was F2119)</para></entry>
-<entry>Home Sale worksheets (replaces Form 2119) are used to report the sale of your personal residence. See IRS Pub 523.</entry>
-</row>
-<row><entry><para><emphasis>  Home Sale \ </emphasis>N393</para><para>Selling price of old home</para></entry>
-<entry>The selling price is the total amount you receive for your home. It includes money, all notes, mortgages, or other debts assumed by the buyer as part of the sale, and the fair market value of any other property or any services you receive. Reported on Form 1099-S.</entry>
-</row>
-<row><entry><para><emphasis>Help Sched B \ </emphasis>H285</para><para>Schedule B - interest and dividend income</para></entry>
-<entry>Schedule B is used to report your interest and dividend income.</entry>
-</row>
-<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N487</para><para>Dividend income, non-taxable</para></entry>
-<entry>Some mutual funds pay shareholders non-taxable dividends. The amount of non-taxable dividends are indicated on your monthly statements or Form 1099-DIV.</entry>
-</row>
-<row><entry><para><emphasis>^ Sched B \ </emphasis>N286</para><para>Dividend income, Ordinary</para></entry>
-<entry>Ordinary dividends from mutual funds, stocks, etc., are reported to you on a 1099-DIV.  Note: these are sometimes called short term capital gain distributions. Do not include (long term) capital gain distributions or non-taxable dividends here, these go on Sched D</entry>
-</row>
-<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N287</para><para>Interest income</para></entry>
-<entry>Taxable interest includes interest you receive from bank accounts, credit unions, loans you made to others. There are several categories of interest, be sure you select the correct one!</entry>
-</row>
-<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N489</para><para>Interest income, non-taxable</para></entry>
-<entry>Non-taxable interest income other than from bonds or notes of states, counties, cities, the District of Columbia, or a possession of the United States, or from a qualified private activity bond. There are several categories of interest, be sure you select the correct one!</entry>
-</row>
-<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N492</para><para>Interest income, OID bonds</para></entry>
-<entry>Interest income from Original Issue Discount (OID) bonds will be reported to you on Form 1099-OID. There are several categories of interest, be sure you select the correct one!</entry>
-</row>
-<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N524</para><para>Interest income, Seller-financed mortgage</para></entry>
-<entry>Interest the buyer paid you on a mortgage or other form of seller financing, for your home or other property and the buyer used the property as a personal residence. There are several categories of interest, be sure you select the correct one!</entry>
-</row>
-<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N289</para><para>Interest income, State and municipal bond</para></entry>
-<entry>Interest on bonds or notes of states, counties, cities, the District of Columbia, or possessions of the United States is generally free of federal income tax (but you may pay state income tax). There are several categories of interest, be sure you select the correct one!</entry>
-</row>
-<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N490</para><para>Interest income, taxed only by fed</para></entry>
-<entry>Interest income that is taxed on your federal return, but not on your state income tax return - other than interest paid on U.S. obligations. There are several categories of interest, be sure you select the correct one!</entry>
-</row>
-<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N491</para><para>Interest income, taxed only by state</para></entry>
-<entry>Interest income that is not taxed on your federal return, but is taxed on your state income tax return - other than interest income from state bonds or notes, the District of Columbia, or a possession of the United States. There are several categories of interest, be sure you select the correct one!</entry>
-</row>
-<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N290</para><para>Interest income, tax-exempt private activity bond</para></entry>
-<entry>Interest income from a qualified tax-exempt private activity bond is not taxable if it meets all requirements. This income is included on your Schedule B as non-taxable interest income. There are several categories of interest, be sure you select the correct one!</entry>
-</row>
-<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N288</para><para>Interest income, US government</para></entry>
-<entry>Interest on U.S. obligations, such as U.S. Treasury bills, notes, and bonds issued by any agency of the United States. This income is exempt from all state and local income taxes. There are several categories of interest, be sure you select the correct one!</entry>
-</row>
-<row><entry><para><emphasis>Help Sched C \ </emphasis>H291</para><para>Schedule C - self-employment income</para></entry>
-<entry>Schedule C is used to report income from self-employment. Use a separate Schedule C to report income and expenses from different businesses.</entry>
-</row>
-<row><entry><para><emphasis>  Sched C \ </emphasis>N293</para><para>Gross receipts or sales</para></entry>
-<entry>The amount of gross receipts from your trade or business. Include amounts you received in your trade or business that were properly shown on Forms 1099-MISC.</entry>
-</row>
-<row><entry><para><emphasis>  Sched C \ </emphasis>N303</para><para>Other business income</para></entry>
-<entry>The amounts from finance reserve income, scrap sales, bad debts you recovered, interest (such as on notes and accounts receivable), state gasoline or fuel tax refunds you got this year, prizes and awards related to your trade or business, and other kinds of miscellaneous business income.</entry>
-</row>
-<row><entry><para><emphasis>Help Sched D \ </emphasis>H320</para><para>Schedule D - capital gains and losses </para></entry>
-<entry>Schedule D is used to report gains and losses from the sale of capital assets.</entry>
-</row>
-<row><entry><para><emphasis>^ Sched D \ </emphasis>N488</para><para>Dividend income, capital gain distributions</para></entry>
-<entry>Sometimes called long term capital gain distributions. These are from mutual funds, other regulated investment companies, or real estate investment trusts.  These are reported on your monthly statements or Form 1099-DIV. Note: short term capital gain distributions are reported on Sched B as ordinary dividends</entry>
-</row>
-<row><entry><para><emphasis># Sched D \ </emphasis>N323</para><para>Long Term gain/loss - security</para></entry>
-<entry>Long term gain or loss from the sale of a security. Not yet implemented in <application>&app;</application>.</entry>
-</row>
-<row><entry><para><emphasis># Sched D \ </emphasis>N321</para><para>Short Term gain/loss - security</para></entry>
-<entry>Short term gain or loss from the sale of a security. Not yet implemented in <application>&app;</application>.</entry>
-</row>
-<row><entry><para><emphasis># Sched D \ </emphasis>N673</para><para>Short/Long Term gain or loss</para></entry>
-<entry>Short term or long term gain or loss from the sale of a security; for use when only the date sold and net sales amount are available and the date acquired and cost basis information is not available and will be separately added in the tax software.</entry>
-</row>
-<row><entry><para><emphasis>Help Sched E \ </emphasis>H325</para><para>Schedule E - rental and royalty income</para></entry>
-<entry>Schedule E is used to report income or loss from rental real estate, royalties, and residual interest in REMIC&rsquo;s. Use a different copy for each rental or royalty. Use the Schedule K-1 categories for partnership rental income and loss amounts.</entry>
-</row>
-<row><entry><para><emphasis>  Sched E \ </emphasis>N326</para><para>Rents received</para></entry>
-<entry>The amounts received as rental income from real estate (including personal property leased with real estate) but you were not in the real estate business. (If you are in the business of renting personal property, use Schedule C.)</entry>
-</row>
-<row><entry><para><emphasis>  Sched E \ </emphasis>N327</para><para>Royalties received</para></entry>
-<entry>Royalties received from oil, gas, or mineral properties (not including operating interests); copyrights; and patents.</entry>
-</row>
-<row><entry><para><emphasis>Help Sched F \ </emphasis>H343</para><para>Schedule F - Farm income and expense</para></entry>
-<entry>Schedule F is used to report farm income and expense. Use a different copy of Schedule F for each farm you own.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N372</para><para>Agricultural program payments</para></entry>
-<entry>Government payments received for: price support payments, market gain from the repayment of a secured Commodity Credit Corporation (CCC) loan for less than the original loan amount, diversion payments, cost-share payments (sight drafts), payments in the form of materials (such as fertilizer or lime) or services (such as grading or building dams). Reported on Form 1099-G.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N374</para><para>CCC loans forfeited or repaid</para></entry>
-<entry>The amount forfeited or repaid with certificates, even if you reported the loan proceeds as income.  See IRS Pub 225.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N373</para><para>CCC loans reported/election</para></entry>
-<entry>Generally, you do not report CCC loan proceeds as income. However, if you pledge part or all of your production to secure a CCC loan, you may elect to report the loan proceeds as income in the year you receive them, instead of the year you sell the crop.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N376</para><para>Crop insurance proceeds deferred</para></entry>
-<entry>If you use the cash method of accounting and receive crop insurance proceeds in the same tax year in which the crops are damaged, you can choose to postpone reporting the proceeds as income until the following tax year. A statement must also be attached to your return.  See IRS Pub 225.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N375</para><para>Crop insurance proceeds received</para></entry>
-<entry>You generally include crop insurance proceeds in the year you receive them. Treat as crop insurance proceeds the crop disaster payments you receive from the federal government.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N370</para><para>Custom hire income</para></entry>
-<entry>The income you received for custom hire (machine work).</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N377</para><para>Other farm income</para></entry>
-<entry>Illegal Federal irrigation subsidies, bartering income, income from discharge of indebtedness, state gasoline or fuel tax refund, the gain or loss on the sale of commodity futures contracts, etc.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N369</para><para>Resales of livestock/items</para></entry>
-<entry>Amounts you received from the sales of livestock and other items you bought specifically for resale. Do not include sales of livestock held for breeding, dairy purposes, draft, or sport.  These are reported on Form 4797, Sales of Business Property.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N368</para><para>Sales livestock/product raised</para></entry>
-<entry>Amounts you received from the sale of livestock, produce, grains, and other products you raised.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N371</para><para>Total cooperative distributions</para></entry>
-<entry>Distributions received from a cooperative. This includes patronage dividends, non patronage distributions, per-unit retain allocations, and redemption of non qualified notices and per unit retain allocations. Reported on Form 1099-PATR.</entry>
-</row>
-<row><entry><para><emphasis>Help Sched K-1 \ </emphasis>H446</para><para>Schedule K-1 - partnership income, credits, deductions</para></entry>
-<entry>Schedule K-1 is used to report your share of a partnership&rsquo;s income, credits, deductions, etc.  Use a separate copy of Schedule K-1 for each partnership.</entry>
-</row>
-<row><entry><para><emphasis>  Sched K-1 \ </emphasis>N452</para><para>Dividends, ordinary</para></entry>
-<entry>The amount of dividend income the partnership reported to you on Schedule K-1. (You report this on Schedule B)</entry>
-</row>
-<row><entry><para><emphasis>  Sched K-1 \ </emphasis>N455</para><para>Guaranteed partner payments</para></entry>
-<entry>A guaranteed payments the partnership reported to you on Schedule K-1. (You report this on Schedule E)</entry>
-</row>
-<row><entry><para><emphasis>  Sched K-1 \ </emphasis>N451</para><para>Interest income</para></entry>
-<entry>The amount of interest income the partnership reported to you on Schedule K-1. (You report this on Schedule B)</entry>
-</row>
-<row><entry><para><emphasis># Sched K-1 \ </emphasis>N454</para><para>Net LT capital gain or loss</para></entry>
-<entry>The long-term gain or (loss) from the sale of assets the partnership reported to you on Schedule K-1. (You report this on Schedule D)</entry>
-</row>
-<row><entry><para><emphasis># Sched K-1 \ </emphasis>N453</para><para>Net ST capital gain or loss</para></entry>
-<entry>The short-term gain or (loss) from sale of assets the partnership reported to you on K-1. (You report this on Schedule D)</entry>
-</row>
-<row><entry><para><emphasis># Sched K-1 \ </emphasis>N456</para><para>Net Section 1231 gain or loss</para></entry>
-<entry>The gain or (loss) from sale of Section 1231 assets the partnership reported to you on Schedule K-1. (You report this on Form 4797)</entry>
-</row>
-<row><entry><para><emphasis># Sched K-1 \ </emphasis>N448</para><para>Ordinary income or loss</para></entry>
-<entry>Your share of the ordinary income (loss) from the trade or business activities of the partnership. This is reported to you on Schedule K-1. (You usually report this on Schedule E, See instructions for Schedule K-1)</entry>
-</row>
-<row><entry><para><emphasis># Sched K-1 \ </emphasis>N450</para><para>Other rental income or loss</para></entry>
-<entry>The income or (loss) from rental activities, other than the rental of real estate.  This is reported to you on Schedule K-1. (You usually report this on Schedule E, See instructions for Schedule K-1)</entry>
-</row>
-<row><entry><para><emphasis># Sched K-1 \ </emphasis>N449</para><para>Rental real estate income or loss</para></entry>
-<entry>The income or (loss) from rental real estate activities engaged in by the partnership. This is reported to you on Schedule K-1. (You usually report this on Schedule E, See instructions for Schedule K-1)</entry>
-</row>
-<row><entry><para><emphasis>  Sched K-1 \ </emphasis>N527</para><para>Royalties</para></entry>
-<entry>The amount of the royalty income the partnership reported to you on Schedule K-1. (You report this on Schedule E)</entry>
-</row>
-<row><entry><para><emphasis>  Sched K-1 \ </emphasis>N528</para><para>Tax-exempt interest income</para></entry>
-<entry>The amount of tax-exempt interest income the partnership reported to you on Schedule K-1. (You report this on Form 1040)</entry>
-</row>
-<row><entry><para><emphasis>Help W-2 \ </emphasis>H458</para><para>Form W-2 - Wages earned and taxes withheld</para></entry>
-<entry>Form W-2 is used by your employer to report the amount of wages and other compensation you earned as an employee, and the amount of federal and state taxes withheld and fringe benefits received. Use a separate copy of Form W-2 for each employer.</entry>
-</row>
-<row><entry><para><emphasis>^ W-2 \ </emphasis>N465</para><para>Dependent care benefits, self</para></entry>
-<entry>The amount dependent care benefits, including the fair market value of employer-provided or employer-sponsored day-care facilities you received.</entry>
-</row>
-<row><entry><para><emphasis>^ W-2 \ </emphasis>N512</para><para>Dependent care benefits, spouse</para></entry>
-<entry>The amount dependent care benefits, including the fair market value of employer-provided or employer-sponsored day-care facilities your spouse received.</entry>
-</row>
-<row><entry><para><emphasis>^ W-2 \ </emphasis>N267</para><para>Reimbursed moving expenses, self</para></entry>
-<entry>Qualified moving expense reimbursements paid directly to you by an employer.</entry>
-</row>
-<row><entry><para><emphasis>^ W-2 \ </emphasis>N546</para><para>Reimbursed moving expenses, spouse</para></entry>
-<entry>Qualified moving expense reimbursements paid directly to your spouse by your spouse&rsquo;s employer.</entry>
-</row>
-<row><entry><para><emphasis>^ W-2 \ </emphasis>N460</para><para>Salary or wages, self</para></entry>
-<entry>The total wages, tips, and other compensation, before any payroll deductions, you receive from your employer.</entry>
-</row>
-<row><entry><para><emphasis>^ W-2 \ </emphasis>N506</para><para>Salary or wages, spouse</para></entry>
-<entry>The total wages, tips, and other compensation, before any payroll deductions, your spouse receives from your spouse&rsquo;s employer.</entry>
-</row>
-<row><entry><para><emphasis>Help W-2G \ </emphasis>H547</para><para>Form W-2G - gambling winnings</para></entry>
-<entry>Form W-2G is used to report certain gambling winnings.</entry>
-</row>
-<row><entry><para><emphasis>^ W-2G \ </emphasis>N549</para><para>Gross winnings</para></entry>
-<entry>The amount of gross winnings from gambling.  This may include winnings from horse racing, dog racing, jai alai, lotteries, keno, bingo, slot machines, sweepstakes, and wagering pools. If the amount is large enough, it will be reported on Form W-2G.</entry>
-</row>
-<row><entry><para><emphasis>  none \ </emphasis>N000</para><para>Tax Report Only - No <acronym>TXF</acronym> Export</para></entry>
-<entry>This is a dummy category and only shows up on the tax report, but is not exported.</entry>
-</row>
-<row><entry><para><emphasis>Help F1040 \ </emphasis>H256</para><para>Form 1040 - the main tax form</para></entry>
-<entry>Form 1040 is the main form of your tax return.</entry>
-</row>
 <row><entry><para><emphasis>  F1040 \ </emphasis>N264</para><para>Alimony paid</para></entry>
 <entry>Amounts payed as alimony or separate maintenance.  Note: child support is not considered alimony.</entry>
 </row>
@@ -450,6 +111,15 @@
 <row><entry><para><emphasis>Help F1099-G \ </emphasis>H634</para><para>Form 1099-G - certain Government payments</para></entry>
 <entry>Form 1099-G is used to report certain government payments from federal, state, or local governments.</entry>
 </row>
+<row><entry><para><emphasis>  F1099-G \ </emphasis>N672</para><para>Qualified state tuition earnings</para></entry>
+<entry>Qualified state tuition program earnings you received this year.</entry>
+</row>
+<row><entry><para><emphasis>  F1099-G \ </emphasis>N260</para><para>State and local tax refunds</para></entry>
+<entry>Refund of state or local income tax refund (or credit or offset) which you deducted or took a credit for in an earlier year. You should receive a statement, Form 1099-G. Not reportable if you didn&rsquo;t itemize last year.</entry>
+</row>
+<row><entry><para><emphasis>  F1099-G \ </emphasis>N479</para><para>Unemployment compensation</para></entry>
+<entry>Total unemployment compensation paid to you this year. Reported on Form 1099-G.</entry>
+</row>
 <row><entry><para><emphasis>  F1099-G \ </emphasis>N606</para><para>Fed tax withheld, unemployment comp</para></entry>
 <entry>The amount of federal income taxes withheld from your unemployment compensation.</entry>
 </row>
@@ -459,14 +129,65 @@
 <row><entry><para><emphasis>Help F1099-MISC \ </emphasis>H553</para><para>Form 1099-MISC - MISCellaneous income</para></entry>
 <entry>Form 1099-MISC is used to report miscellaneous income received and direct sales of consumer goods for resale.</entry>
 </row>
+<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N562</para><para>Crop insurance proceeds</para></entry>
+<entry>The amount of crop insurance proceeds as the result of crop damage.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N559</para><para>Fishing boat proceeds</para></entry>
+<entry>Your share of all proceeds from the sale of a catch or the fair market value of a distribution in kind that you received as a crew member of a fishing boat.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N560</para><para>Medical/health payments</para></entry>
+<entry>The amount of payments received as a physician or other supplier or provider of medical or health care services. This includes payments made by medical and health care insurers under health, accident, and sickness insurance programs.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N561</para><para>Non employee compensation</para></entry>
+<entry>The amount of non-employee compensation received. This includes fees, commissions, prizes and awards for services performed, other forms of compensation for services you performed for a trade or business by which you are not employed.  Also include oil and gas payments for a working interest.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N557</para><para>Other income</para></entry>
+<entry>The amount of prizes and awards that are not for services performed. Included is the fair market value of merchandise won on game shows. Included is all punitive damages, any damages for nonphysical injuries or sickness, and any other taxable damages, Deceased employee&rsquo;s wages paid to estate or beneficiary.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N259</para><para>Prizes and awards</para></entry>
+<entry>The amount of prizes and awards that are not for services performed. Included is the fair market value of merchandise won on game shows.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N555</para><para>Rents</para></entry>
+<entry>Amounts received for all types of rents, such as real estate rentals for office space, machine rentals, and pasture rentals.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N556</para><para>Royalties</para></entry>
+<entry>The gross royalty payments received from a publisher or literary agent.</entry>
+</row>
 <row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N558</para><para>Federal tax withheld</para></entry>
 <entry>The amount of federal income tax withheld (backup withholding) from 1099-MISC income.</entry>
 </row>
 <row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N563</para><para>State tax withheld</para></entry>
 <entry>The amount of state income tax withheld (state backup withholding) from 1099-MISC income.</entry>
 </row>
+<row><entry><para><emphasis>Help F1099=MSA \ </emphasis>H629</para><para>Form 1099-MSA Medical Savings Account</para></entry>
+<entry>Form 1099-MSA is used to report medical savings account distributions.</entry>
+</row>
+<row><entry><para><emphasis>  F1099-MSA \ </emphasis>N632</para><para>MSA earnings on excess contrib</para></entry>
+<entry>The earnings on any excess contributions you withdrew from an MSA by the due date of your income tax return. If you withdrew the excess, plus any earnings, by the due date of your income tax return, you must include the earnings in your income in the year you received the distribution even if you used it to pay qualified medical expenses.</entry>
+</row>
+<row><entry><para><emphasis>  F1099-MSA \ </emphasis>N631</para><para>MSA gross distribution</para></entry>
+<entry>The amount you received this year from a Medical Savings Account. The amount may have been a direct payment to the medical service provider or distributed to you.</entry>
+</row>
 <row><entry><para><emphasis>Help F1099-R \ </emphasis>H473</para><para>Form 1099-R - Retirement distributions</para></entry>
 <entry>Form 1099-R is used to report taxable and non-taxable retirement distributions from retirement, pension, profit-sharing, or annuity plans. Use a separate Form 1099-R for each payer.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-R \ </emphasis>N623</para><para>SIMPLE total gross distribution</para></entry>
+<entry>The gross amount of a distribution received from a qualified SIMPLE pension plan.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-R \ </emphasis>N624</para><para>SIMPLE total taxable distribution</para></entry>
+<entry>The taxable amount of a distribution received from a qualified SIMPLE plan. This amount may be subject to a federal penalty of up to 25%.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-R \ </emphasis>N477</para><para>Total IRA gross distribution</para></entry>
+<entry>The gross amount of a distribution from a qualified Individual Retirement Arrangement (IRA) plan.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-R \ </emphasis>N478</para><para>Total IRA taxable distribution</para></entry>
+<entry>The taxable amount of a distribution from a qualified Individual Retirement Arrangement (IRA) plan.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-R \ </emphasis>N475</para><para>Total pension gross distribution</para></entry>
+<entry>The gross amount of a distribution from a qualified pension or annuity plan. Note: IRA distributions are not included here.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-R \ </emphasis>N476</para><para>Total pension taxable distribution</para></entry>
+<entry>The taxable amount of a distribution from a qualified pension or annuity plan. Note: IRA distributions are not included here.</entry>
 </row>
 <row><entry><para><emphasis>^ F1099-R \ </emphasis>N532</para><para>IRA federal tax withheld</para></entry>
 <entry>The amount of federal income taxes withheld from your IRA distribution.</entry>
@@ -498,6 +219,12 @@
 <row><entry><para><emphasis>Help F2106 \ </emphasis>H380</para><para>employee business expenses</para></entry>
 <entry>Form 2106 is used to deduct employee business expenses. You must file this form if you were reimbursed by your employer or claim job-related travel, transportation, meal, or entertainment expenses. Use a separate Form 2106 for your spouse&rsquo;s expenses.</entry>
 </row>
+<row><entry><para><emphasis>  F2106 \ </emphasis>N387</para><para>Reimb. business expenses (non-meal/ent.)</para></entry>
+<entry>Reimbursement for business expenses from your employer that is NOT included on your Form W-2. Note: meals and entertainment are NOT included here.</entry>
+</row>
+<row><entry><para><emphasis>  F2106 \ </emphasis>N388</para><para>Reimb. meal/entertainment expenses</para></entry>
+<entry>Reimbursement for meal and entertainment expenses from your employer that is NOT included on your Form W-2.</entry>
+</row>
 <row><entry><para><emphasis>  F2106 \ </emphasis>N382</para><para>Automobile expenses</para></entry>
 <entry>Total annual expenses for gasoline, oil, repairs, insurance, tires, license plates, or similar items.</entry>
 </row>
@@ -525,6 +252,12 @@
 <row><entry><para><emphasis>  F2106 \ </emphasis>N383</para><para>Travel (away from home)</para></entry>
 <entry>Travel expenses are those incurred while traveling away from home for your employer. The cost of getting to and from your business destination (air, rail, bus, car, etc.), taxi fares, baggage charges, and cleaning and laundry expenses. Note: meal and entertainment expenses are not included here.</entry>
 </row>
+<row><entry><para><emphasis>Help F4137 \ </emphasis>H503</para><para>Form 4137 - tips not reported</para></entry>
+<entry>Form 4137 is used to compute social security and Medicare tax owed on tips you did not report to your employer.</entry>
+</row>
+<row><entry><para><emphasis>  F4137 \ </emphasis>N505</para><para>Total cash/tips not reported to employer</para></entry>
+<entry>The amount of tips you did not report to your employer.</entry>
+</row>
 <row><entry><para><emphasis>Help F2441 \ </emphasis>H400</para><para>Form 2441 - child and dependent credit</para></entry>
 <entry>Form 2441 is used to claim a credit for child and dependent care expenses.</entry>
 </row>
@@ -546,11 +279,44 @@
 <row><entry><para><emphasis>Help F4684 \ </emphasis>H412</para><para>Form 4684 - casualties and thefts</para></entry>
 <entry>Form 4684 is used to report gains and losses from casualties and thefts.</entry>
 </row>
+<row><entry><para><emphasis>  F4684 \ </emphasis>N416</para><para>FMV after casualty</para></entry>
+<entry>The fair market value (FMV) is the price at which the property would change hands between a willing buyer and seller, each having knowledge of the relevant facts. The FMV after a theft is zero if the property is not recovered. The FMV is generally determined by competent appraisal.</entry>
+</row>
+<row><entry><para><emphasis>  F4684 \ </emphasis>N415</para><para>FMV before casualty</para></entry>
+<entry>The fair market value (FMV) is the price at which the property would change hands between a willing buyer and seller, each having knowledge of the relevant facts. FMV is generally determined by competent appraisal.</entry>
+</row>
+<row><entry><para><emphasis>  F4684 \ </emphasis>N414</para><para>Insurance/reimbursement</para></entry>
+<entry>The amount of insurance or other reimbursement you received expect to receive.</entry>
+</row>
 <row><entry><para><emphasis>  F4684 \ </emphasis>N413</para><para>Basis of casualty property</para></entry>
 <entry>Cost or other basis usually means original cost plus improvements. Subtract any postponed gain from the sale of a previous main home. Special rules apply to property received as a gift or inheritance. See Pub  551, Basis of Assets, for details.</entry>
 </row>
 <row><entry><para><emphasis>Help F4835 \ </emphasis>H569</para><para>Form 4835 - farm rental income</para></entry>
 <entry>Form 4835 is used to report farm rental income received as a share of crops or livestock produced by your tenant if you did not materially participate in the operation or management of the farm.  Use a different copy of Form 4835 for each farm rented.</entry>
+</row>
+<row><entry><para><emphasis>  F4835 \ </emphasis>N573</para><para>Agricultural program payments</para></entry>
+<entry>Government payments received for: price support payments, market gain from the repayment of a secured Commodity Credit Corporation (CCC) loan for less than the original loan amount, diversion payments, cost-share payments (sight drafts), payments in the form of materials (such as fertilizer or lime) or services (such as grading or building dams). Reported on Form 1099-G.</entry>
+</row>
+<row><entry><para><emphasis>  F4835 \ </emphasis>N575</para><para>CCC loans forfeited/repaid</para></entry>
+<entry>The full amount forfeited or repaid with certificates, even if you reported the loan proceeds as income.  See IRS Pub 225.</entry>
+</row>
+<row><entry><para><emphasis>  F4835 \ </emphasis>N574</para><para>CCC loans reported/election</para></entry>
+<entry>Generally, you do not report CCC loan proceeds as income. However, if you pledge part or all of your production to secure a CCC loan, you may elect to report the loan proceeds as income in the year you receive them, instead of the year you sell the crop.</entry>
+</row>
+<row><entry><para><emphasis>  F4835 \ </emphasis>N577</para><para>Crop insurance proceeds deferred</para></entry>
+<entry>If you use the cash method of accounting and receive crop insurance proceeds in the same tax year in which the crops are damaged, you can choose to postpone reporting the proceeds as income until the following tax year. A statement must also be attached to your return.  See IRS Pub 225.</entry>
+</row>
+<row><entry><para><emphasis>  F4835 \ </emphasis>N576</para><para>Crop insurance proceeds received</para></entry>
+<entry>You generally include crop insurance proceeds in the year you receive them. Treat as crop insurance proceeds the crop disaster payments you receive from the federal government.</entry>
+</row>
+<row><entry><para><emphasis>  F4835 \ </emphasis>N578</para><para>Other income</para></entry>
+<entry>Illegal Federal irrigation subsidies, bartering income, income from discharge of indebtedness, state gasoline or fuel tax refund, the gain or loss on the sale of commodity futures contracts, etc.</entry>
+</row>
+<row><entry><para><emphasis>  F4835 \ </emphasis>N571</para><para>Sale of livestock/produce</para></entry>
+<entry>Income you received from livestock, produce, grains, and other crops based on production. Under both the cash and the accrual methods of reporting, you must report livestock or crop share rentals received in the year you convert them into money or its equivalent.</entry>
+</row>
+<row><entry><para><emphasis>  F4835 \ </emphasis>N572</para><para>Total cooperative distributions</para></entry>
+<entry>Distributions received from a cooperative. This includes patronage dividends, non patronage distributions, per-unit retain allocations, and redemption of non qualified notices and per unit retain allocations. Reported on Form 1099-PATR.</entry>
 </row>
 <row><entry><para><emphasis>  F4835 \ </emphasis>N579</para><para>Car and truck expenses</para></entry>
 <entry>The business portion of car or truck expenses, such as, for gasoline, oil, repairs, insurance, tires, license plates, etc.</entry>
@@ -633,14 +399,47 @@
 <row><entry><para><emphasis>Help F6252 \ </emphasis>H427</para><para>Form 6252 - income from casual sales</para></entry>
 <entry>Form 6252 is used to report income from casual sales of real or personal property when you will receive any payments in a tax year after the year of sale (i.e., installment sale).</entry>
 </row>
+<row><entry><para><emphasis>  F6252 \ </emphasis>N429</para><para>Debt assumed by buyer</para></entry>
+<entry>Enter only mortgages or other debts the buyer assumed from the seller or took the property subject to. Do not include new mortgages the buyer gets from a bank, the seller, or other sources.</entry>
+</row>
+<row><entry><para><emphasis>  F6252 \ </emphasis>N431</para><para>Depreciation allowed</para></entry>
+<entry>Enter all depreciation or amortization you deducted or should have deducted from the date of purchase until the date of sale. Add any section 179 expense deduction.  Several other adjustments are allowed, See Form 6252 instructions.</entry>
+</row>
+<row><entry><para><emphasis>  F6252 \ </emphasis>N435</para><para>Payments received prior years</para></entry>
+<entry>Enter all money and the fair market value (FMV) of property you received before this tax year from the sale. Include allocable installment income and any other deemed payments from prior years. Do not include interest whether stated or unstated.</entry>
+</row>
+<row><entry><para><emphasis>  F6252 \ </emphasis>N434</para><para>Payments received this year</para></entry>
+<entry>Enter all money and the fair market value (FMV) of any property you received in this tax year. Include as payments any amount withheld to pay off a mortgage or other debt, such as broker and legal fees. Do not include interest whether stated or unstated.</entry>
+</row>
+<row><entry><para><emphasis>  F6252 \ </emphasis>N428</para><para>Selling price</para></entry>
+<entry>Enter the total of any money, face amount of the installment obligation, and the FMV of other property that you received or will receive in exchange for the property sold.</entry>
+</row>
 <row><entry><para><emphasis>  F6252 \ </emphasis>N432</para><para>Expenses of sale</para></entry>
 <entry>Enter sales commissions, advertising expenses, attorney and legal fees, etc., in selling the property.</entry>
 </row>
 <row><entry><para><emphasis>Help F8815 \ </emphasis>H441</para><para>Form 8815 - EE U.S. savings bonds sold for education</para></entry>
 <entry>Form 8815 is used to compute the amount of interest you may exclude if you cashed series EE U.S. savings bonds this year that were issued after 1989 to pay for qualified higher education costs.</entry>
 </row>
+<row><entry><para><emphasis>  F8815 \ </emphasis>N444</para><para>EE US savings bonds proceeds</para></entry>
+<entry>Enter the total proceeds (principal and interest) from all series EE and I U.S. savings bonds issued after 1989 that you cashed during this tax year.</entry>
+</row>
+<row><entry><para><emphasis>  F8815 \ </emphasis>N443</para><para>Nontaxable education benefits</para></entry>
+<entry>Nontaxable educational benefits. These benefits include: Scholarship or fellowship grants excludable from income under section 117; Veterans&rsquo; educational assistance benefits; Employer-provided educational assistance benefits that are not included in box 1 of your W-2 form(s); Any other payments (but not gifts, bequests, or inheritances) for educational expenses that are exempt from income tax by any U.S. law. Do not include nontaxable educational benefits paid directly to, or by, the educational institution.</entry>
+</row>
+<row><entry><para><emphasis>  F8815 \ </emphasis>N445</para><para>Post-89 EE bond face value</para></entry>
+<entry>The face value of all post-1989 series EE bonds cashed this tax year.</entry>
+</row>
 <row><entry><para><emphasis>  F8815 \ </emphasis>N442</para><para>Qualified higher education expenses</para></entry>
 <entry>Qualified higher education expenses include tuition and fees required for the enrollment or attendance of the person(s). Do not include expenses for room and board, or courses involving sports, games, or hobbies that are not part of a degree or certificate granting program.</entry>
+</row>
+<row><entry><para><emphasis>Help F8863 \ </emphasis>H639</para><para>Form 8863 - Hope and Lifetime Learning education credits</para></entry>
+<entry>Form 8863 is used to compute the Hope and Lifetime Learning education credits. IRS rules are stringent for these credits.  Refer to IRS Publication 970 for more information.</entry>
+</row>
+<row><entry><para><emphasis>  F8863 \ </emphasis>N637</para><para>Hope credit</para></entry>
+<entry>Expenses qualified for the Hope credit are amounts paid this tax year for tuition and fees required for the student&rsquo;s enrollment or attendance at an eligible educational institution.</entry>
+</row>
+<row><entry><para><emphasis>  F8863 \ </emphasis>N638</para><para>Lifetime learning credit</para></entry>
+<entry>Expenses qualified for the Lifetime Learning credit are amounts paid this tax year for tuition and fees required for the student&rsquo;s enrollment or attendance at an eligible educational institution.</entry>
 </row>
 <row><entry><para><emphasis>Help F8829 \ </emphasis>H536</para><para>Form 8829 - business use of your home</para></entry>
 <entry>Form 8829 is used only if you file a Schedule C, Profit or Loss from Business, and you meet specific requirements to deduct expenses for the business use of your home.  IRS rules are stringent for this deduction.  Refer to IRS Publication 587.</entry>
@@ -680,6 +479,12 @@
 </row>
 <row><entry><para><emphasis>  F8839 \ </emphasis>N621</para><para>Traveling expenses</para></entry>
 <entry>Traveling expenses (including meals and lodging) while away from home, directly related to, and for the principal purpose of, the legal adoption of an eligible child.</entry>
+</row>
+<row><entry><para><emphasis>  Home Sale \ </emphasis>N392</para><para>Home Sale worksheets (was F2119)</para></entry>
+<entry>Home Sale worksheets (replaces Form 2119) are used to report the sale of your personal residence. See IRS Pub 523.</entry>
+</row>
+<row><entry><para><emphasis>  Home Sale \ </emphasis>N393</para><para>Selling price of old home</para></entry>
+<entry>The selling price is the total amount you receive for your home. It includes money, all notes, mortgages, or other debts assumed by the buyer as part of the sale, and the fair market value of any other property or any services you receive. Reported on Form 1099-S.</entry>
 </row>
 <row><entry><para><emphasis>  Home Sale \ </emphasis>N392</para><para>Home Sale worksheets (was F2119)</para></entry>
 <entry>Home Sale worksheets (replaces Form 2119) are used to report the sale of your personal residence. See IRS Pub 523.</entry>
@@ -762,6 +567,39 @@ The fair market value of donated property, such as used clothing or furniture.</
 <row><entry><para><emphasis>Help Sched B \ </emphasis>H285</para><para>Schedule B - interest and dividend income</para></entry>
 <entry>Schedule B is used to report your interest and dividend income.</entry>
 </row>
+<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N487</para><para>Dividend income, non-taxable</para></entry>
+<entry>Some mutual funds pay shareholders non-taxable dividends. The amount of non-taxable dividends are indicated on your monthly statements or Form 1099-DIV.</entry>
+</row>
+<row><entry><para><emphasis>^ Sched B \ </emphasis>N286</para><para>Dividend income, Ordinary</para></entry>
+<entry>Ordinary dividends from mutual funds, stocks, etc., are reported to you on a 1099-DIV.  Note: these are sometimes called short term capital gain distributions. Do not include (long term) capital gain distributions or non-taxable dividends here, these go on Sched D</entry>
+</row>
+<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N287</para><para>Interest income</para></entry>
+<entry>Taxable interest includes interest you receive from bank accounts, credit unions, loans you made to others. There are several categories of interest, be sure you select the correct one!</entry>
+</row>
+<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N489</para><para>Interest income, non-taxable</para></entry>
+<entry>Non-taxable interest income other than from bonds or notes of states, counties, cities, the District of Columbia, or a possession of the United States, or from a qualified private activity bond. There are several categories of interest, be sure you select the correct one!</entry>
+</row>
+<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N492</para><para>Interest income, OID bonds</para></entry>
+<entry>Interest income from Original Issue Discount (OID) bonds will be reported to you on Form 1099-OID. There are several categories of interest, be sure you select the correct one!</entry>
+</row>
+<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N524</para><para>Interest income, Seller-financed mortgage</para></entry>
+<entry>Interest the buyer paid you on a mortgage or other form of seller financing, for your home or other property and the buyer used the property as a personal residence. There are several categories of interest, be sure you select the correct one!</entry>
+</row>
+<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N289</para><para>Interest income, State and municipal bond</para></entry>
+<entry>Interest on bonds or notes of states, counties, cities, the District of Columbia, or possessions of the United States is generally free of federal income tax (but you may pay state income tax). There are several categories of interest, be sure you select the correct one!</entry>
+</row>
+<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N490</para><para>Interest income, taxed only by fed</para></entry>
+<entry>Interest income that is taxed on your federal return, but not on your state income tax return - other than interest paid on U.S. obligations. There are several categories of interest, be sure you select the correct one!</entry>
+</row>
+<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N491</para><para>Interest income, taxed only by state</para></entry>
+<entry>Interest income that is not taxed on your federal return, but is taxed on your state income tax return - other than interest income from state bonds or notes, the District of Columbia, or a possession of the United States. There are several categories of interest, be sure you select the correct one!</entry>
+</row>
+<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N290</para><para>Interest income, tax-exempt private activity bond</para></entry>
+<entry>Interest income from a qualified tax-exempt private activity bond is not taxable if it meets all requirements. This income is included on your Schedule B as non-taxable interest income. There are several categories of interest, be sure you select the correct one!</entry>
+</row>
+<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N288</para><para>Interest income, US government</para></entry>
+<entry>Interest on U.S. obligations, such as U.S. Treasury bills, notes, and bonds issued by any agency of the United States. This income is exempt from all state and local income taxes. There are several categories of interest, be sure you select the correct one!</entry>
+</row>
 <row><entry><para><emphasis>&lt; Sched B \ </emphasis>N615</para><para>Fed tax withheld, dividend income</para></entry>
 <entry>The amount of federal income taxes withheld from dividend income. This is usually reported on Form 1099-DIV.</entry>
 </row>
@@ -770,6 +608,12 @@ The fair market value of donated property, such as used clothing or furniture.</
 </row>
 <row><entry><para><emphasis>Help Sched C \ </emphasis>H291</para><para>Schedule C - self-employment income</para></entry>
 <entry>Schedule C is used to report income from self-employment. Use a separate Schedule C to report income and expenses from different businesses.</entry>
+</row>
+<row><entry><para><emphasis>  Sched C \ </emphasis>N293</para><para>Gross receipts or sales</para></entry>
+<entry>The amount of gross receipts from your trade or business. Include amounts you received in your trade or business that were properly shown on Forms 1099-MISC.</entry>
+</row>
+<row><entry><para><emphasis>  Sched C \ </emphasis>N303</para><para>Other business income</para></entry>
+<entry>The amounts from finance reserve income, scrap sales, bad debts you recovered, interest (such as on notes and accounts receivable), state gasoline or fuel tax refunds you got this year, prizes and awards related to your trade or business, and other kinds of miscellaneous business income.</entry>
 </row>
 <row><entry><para><emphasis>  Sched C \ </emphasis>N304</para><para>Advertising</para></entry>
 <entry>The amounts paid for advertising your trade or business in newspapers, publications, radio or television. Also include the cost of brochures, business cards, or other promotional material.</entry>
@@ -852,8 +696,29 @@ The fair market value of donated property, such as used clothing or furniture.</
 <row><entry><para><emphasis>  Sched C \ </emphasis>N297</para><para>Wages paid</para></entry>
 <entry>The total amount of salaries and wages for the tax year. Do not include amounts paid to yourself.</entry>
 </row>
+<row><entry><para><emphasis>Help Sched D \ </emphasis>H320</para><para>Schedule D - capital gains and losses </para></entry>
+<entry>Schedule D is used to report gains and losses from the sale of capital assets.</entry>
+</row>
+<row><entry><para><emphasis>^ Sched D \ </emphasis>N488</para><para>Dividend income, capital gain distributions</para></entry>
+<entry>Sometimes called long term capital gain distributions. These are from mutual funds, other regulated investment companies, or real estate investment trusts.  These are reported on your monthly statements or Form 1099-DIV. Note: short term capital gain distributions are reported on Sched B as ordinary dividends</entry>
+</row>
+<row><entry><para><emphasis># Sched D \ </emphasis>N323</para><para>Long Term gain/loss - security</para></entry>
+<entry>Long term gain or loss from the sale of a security. Not yet implemented in <application>&app;</application>.</entry>
+</row>
+<row><entry><para><emphasis># Sched D \ </emphasis>N321</para><para>Short Term gain/loss - security</para></entry>
+<entry>Short term gain or loss from the sale of a security. Not yet implemented in <application>&app;</application>.</entry>
+</row>
+<row><entry><para><emphasis># Sched D \ </emphasis>N673</para><para>Short/Long Term gain or loss</para></entry>
+<entry>Short term or long term gain or loss from the sale of a security; for use when only the date sold and net sales amount are available and the date acquired and cost basis information is not available and will be separately added in the tax software.</entry>
+</row>
 <row><entry><para><emphasis>Help Sched E \ </emphasis>H325</para><para>Schedule E - rental and royalty income</para></entry>
 <entry>Schedule E is used to report income or loss from rental real estate, royalties, and residual interest in REMIC&rsquo;s. Use a different copy for each rental or royalty. Use the Schedule K-1 categories for partnership rental income and loss amounts.</entry>
+</row>
+<row><entry><para><emphasis>  Sched E \ </emphasis>N326</para><para>Rents received</para></entry>
+<entry>The amounts received as rental income from real estate (including personal property leased with real estate) but you were not in the real estate business. (If you are in the business of renting personal property, use Schedule C.)</entry>
+</row>
+<row><entry><para><emphasis>  Sched E \ </emphasis>N327</para><para>Royalties received</para></entry>
+<entry>Royalties received from oil, gas, or mineral properties (not including operating interests); copyrights; and patents.</entry>
 </row>
 <row><entry><para><emphasis>  Sched E \ </emphasis>N328</para><para>Advertising</para></entry>
 <entry>Amounts paid to advertise rental unit(s) in newspapers or other media or paid to realtor&rsquo;s to obtain tenants.</entry>
@@ -899,6 +764,36 @@ The fair market value of donated property, such as used clothing or furniture.</
 </row>
 <row><entry><para><emphasis>Help Sched F \ </emphasis>H343</para><para>Schedule F - Farm income and expense</para></entry>
 <entry>Schedule F is used to report farm income and expense. Use a different copy of Schedule F for each farm you own.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N372</para><para>Agricultural program payments</para></entry>
+<entry>Government payments received for: price support payments, market gain from the repayment of a secured Commodity Credit Corporation (CCC) loan for less than the original loan amount, diversion payments, cost-share payments (sight drafts), payments in the form of materials (such as fertilizer or lime) or services (such as grading or building dams). Reported on Form 1099-G.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N374</para><para>CCC loans forfeited or repaid</para></entry>
+<entry>The amount forfeited or repaid with certificates, even if you reported the loan proceeds as income.  See IRS Pub 225.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N373</para><para>CCC loans reported/election</para></entry>
+<entry>Generally, you do not report CCC loan proceeds as income. However, if you pledge part or all of your production to secure a CCC loan, you may elect to report the loan proceeds as income in the year you receive them, instead of the year you sell the crop.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N376</para><para>Crop insurance proceeds deferred</para></entry>
+<entry>If you use the cash method of accounting and receive crop insurance proceeds in the same tax year in which the crops are damaged, you can choose to postpone reporting the proceeds as income until the following tax year. A statement must also be attached to your return.  See IRS Pub 225.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N375</para><para>Crop insurance proceeds received</para></entry>
+<entry>You generally include crop insurance proceeds in the year you receive them. Treat as crop insurance proceeds the crop disaster payments you receive from the federal government.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N370</para><para>Custom hire income</para></entry>
+<entry>The income you received for custom hire (machine work).</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N377</para><para>Other farm income</para></entry>
+<entry>Illegal Federal irrigation subsidies, bartering income, income from discharge of indebtedness, state gasoline or fuel tax refund, the gain or loss on the sale of commodity futures contracts, etc.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N369</para><para>Resales of livestock/items</para></entry>
+<entry>Amounts you received from the sales of livestock and other items you bought specifically for resale. Do not include sales of livestock held for breeding, dairy purposes, draft, or sport.  These are reported on Form 4797, Sales of Business Property.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N368</para><para>Sales livestock/product raised</para></entry>
+<entry>Amounts you received from the sale of livestock, produce, grains, and other products you raised.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N371</para><para>Total cooperative distributions</para></entry>
+<entry>Distributions received from a cooperative. This includes patronage dividends, non patronage distributions, per-unit retain allocations, and redemption of non qualified notices and per unit retain allocations. Reported on Form 1099-PATR.</entry>
 </row>
 <row><entry><para><emphasis>  Sched F \ </emphasis>N543</para><para>Car and truck expenses</para></entry>
 <entry>The business portion of car or truck expenses, such as, for gasoline, oil, repairs, insurance, tires, license plates, etc.</entry>
@@ -984,8 +879,62 @@ The fair market value of donated property, such as used clothing or furniture.</
 <row><entry><para><emphasis>^ Sched H \ </emphasis>N568</para><para>Federal tax withheld</para></entry>
 <entry>Federal income tax withheld from total cash wages paid to household employees during the year.</entry>
 </row>
+<row><entry><para><emphasis>Help Sched K-1 \ </emphasis>H446</para><para>Schedule K-1 - partnership income, credits, deductions</para></entry>
+<entry>Schedule K-1 is used to report your share of a partnership&rsquo;s income, credits, deductions, etc.  Use a separate copy of Schedule K-1 for each partnership.</entry>
+</row>
+<row><entry><para><emphasis>  Sched K-1 \ </emphasis>N452</para><para>Dividends, ordinary</para></entry>
+<entry>The amount of dividend income the partnership reported to you on Schedule K-1. (You report this on Schedule B)</entry>
+</row>
+<row><entry><para><emphasis>  Sched K-1 \ </emphasis>N455</para><para>Guaranteed partner payments</para></entry>
+<entry>A guaranteed payments the partnership reported to you on Schedule K-1. (You report this on Schedule E)</entry>
+</row>
+<row><entry><para><emphasis>  Sched K-1 \ </emphasis>N451</para><para>Interest income</para></entry>
+<entry>The amount of interest income the partnership reported to you on Schedule K-1. (You report this on Schedule B)</entry>
+</row>
+<row><entry><para><emphasis># Sched K-1 \ </emphasis>N454</para><para>Net LT capital gain or loss</para></entry>
+<entry>The long-term gain or (loss) from the sale of assets the partnership reported to you on Schedule K-1. (You report this on Schedule D)</entry>
+</row>
+<row><entry><para><emphasis># Sched K-1 \ </emphasis>N453</para><para>Net ST capital gain or loss</para></entry>
+<entry>The short-term gain or (loss) from sale of assets the partnership reported to you on K-1. (You report this on Schedule D)</entry>
+</row>
+<row><entry><para><emphasis># Sched K-1 \ </emphasis>N456</para><para>Net Section 1231 gain or loss</para></entry>
+<entry>The gain or (loss) from sale of Section 1231 assets the partnership reported to you on Schedule K-1. (You report this on Form 4797)</entry>
+</row>
+<row><entry><para><emphasis># Sched K-1 \ </emphasis>N448</para><para>Ordinary income or loss</para></entry>
+<entry>Your share of the ordinary income (loss) from the trade or business activities of the partnership. This is reported to you on Schedule K-1. (You usually report this on Schedule E, See instructions for Schedule K-1)</entry>
+</row>
+<row><entry><para><emphasis># Sched K-1 \ </emphasis>N450</para><para>Other rental income or loss</para></entry>
+<entry>The income or (loss) from rental activities, other than the rental of real estate.  This is reported to you on Schedule K-1. (You usually report this on Schedule E, See instructions for Schedule K-1)</entry>
+</row>
+<row><entry><para><emphasis># Sched K-1 \ </emphasis>N449</para><para>Rental real estate income or loss</para></entry>
+<entry>The income or (loss) from rental real estate activities engaged in by the partnership. This is reported to you on Schedule K-1. (You usually report this on Schedule E, See instructions for Schedule K-1)</entry>
+</row>
+<row><entry><para><emphasis>  Sched K-1 \ </emphasis>N527</para><para>Royalties</para></entry>
+<entry>The amount of the royalty income the partnership reported to you on Schedule K-1. (You report this on Schedule E)</entry>
+</row>
+<row><entry><para><emphasis>  Sched K-1 \ </emphasis>N528</para><para>Tax-exempt interest income</para></entry>
+<entry>The amount of tax-exempt interest income the partnership reported to you on Schedule K-1. (You report this on Form 1040)</entry>
+</row>
 <row><entry><para><emphasis>Help W-2 \ </emphasis>H458</para><para>Form W-2 - Wages earned and taxes withheld</para></entry>
 <entry>Form W-2 is used by your employer to report the amount of wages and other compensation you earned as an employee, and the amount of federal and state taxes withheld and fringe benefits received. Use a separate copy of Form W-2 for each employer.</entry>
+</row>
+<row><entry><para><emphasis>^ W-2 \ </emphasis>N465</para><para>Dependent care benefits, self</para></entry>
+<entry>The amount dependent care benefits, including the fair market value of employer-provided or employer-sponsored day-care facilities you received.</entry>
+</row>
+<row><entry><para><emphasis>^ W-2 \ </emphasis>N512</para><para>Dependent care benefits, spouse</para></entry>
+<entry>The amount dependent care benefits, including the fair market value of employer-provided or employer-sponsored day-care facilities your spouse received.</entry>
+</row>
+<row><entry><para><emphasis>^ W-2 \ </emphasis>N267</para><para>Reimbursed moving expenses, self</para></entry>
+<entry>Qualified moving expense reimbursements paid directly to you by an employer.</entry>
+</row>
+<row><entry><para><emphasis>^ W-2 \ </emphasis>N546</para><para>Reimbursed moving expenses, spouse</para></entry>
+<entry>Qualified moving expense reimbursements paid directly to your spouse by your spouse&rsquo;s employer.</entry>
+</row>
+<row><entry><para><emphasis>^ W-2 \ </emphasis>N460</para><para>Salary or wages, self</para></entry>
+<entry>The total wages, tips, and other compensation, before any payroll deductions, you receive from your employer.</entry>
+</row>
+<row><entry><para><emphasis>^ W-2 \ </emphasis>N506</para><para>Salary or wages, spouse</para></entry>
+<entry>The total wages, tips, and other compensation, before any payroll deductions, your spouse receives from your spouse&rsquo;s employer.</entry>
 </row>
 <row><entry><para><emphasis>^ W-2 \ </emphasis>N461</para><para>Federal tax withheld, self</para></entry>
 <entry>The amount of Federal income tax withheld from your wages for the year.</entry>
@@ -1019,6 +968,9 @@ The fair market value of donated property, such as used clothing or furniture.</
 </row>
 <row><entry><para><emphasis>Help W-2G \ </emphasis>H547</para><para>Form W-2G - gambling winnings</para></entry>
 <entry>Form W-2G is used to report certain gambling winnings.</entry>
+</row>
+<row><entry><para><emphasis>^ W-2G \ </emphasis>N549</para><para>Gross winnings</para></entry>
+<entry>The amount of gross winnings from gambling.  This may include winnings from horse racing, dog racing, jai alai, lotteries, keno, bingo, slot machines, sweepstakes, and wagering pools. If the amount is large enough, it will be reported on Form W-2G.</entry>
 </row>
 <row><entry><para><emphasis>^ W-2G \ </emphasis>N550</para><para>Federal tax withheld</para></entry>
 <entry>The amount of federal income taxes withheld from gross gambling winnings.</entry>

--- a/help/C/Help_txf-categories.xml
+++ b/help/C/Help_txf-categories.xml
@@ -30,26 +30,17 @@
 <row><entry><para><emphasis>  F1040 \ </emphasis>N257</para><para>Other income, misc.</para></entry>
 <entry>Miscellaneous income such as: a hobby or a farm you operate mostly for recreation and pleasure, jury duty pay. Exclude self employment income, gambling winnings, prizes and awards.</entry>
 </row>
-<row><entry><para><emphasis>  F1040 \ </emphasis>N520</para><para>RR retirement inc., spouse</para></entry>
-<entry>Spouse&rsquo;s part of tier I railroad retirement benefits, which are treated as a social security benefits. These will be reported on Form RRB-1099.</entry>
-</row>
-<row><entry><para><emphasis>  F1040 \ </emphasis>N519</para><para>RR retirement income, self</para></entry>
-<entry>The part of tier I railroad retirement benefits, which are treated as a social security benefits. These will be reported on Form RRB-1099.</entry>
-</row>
 <row><entry><para><emphasis>  F1040 \ </emphasis>N258</para><para>Sick pay or disability pay</para></entry>
 <entry>Amounts you receive from your employer while you are sick or injured are part of your salary or wages. Exclude workers&rsquo; compensation, accident or health insurance policy benefits, if you paid the premiums.</entry>
-</row>
-<row><entry><para><emphasis>  F1040 \ </emphasis>N483</para><para>Social Security inc., spouse</para></entry>
-<entry>Spouse&rsquo;s part of any monthly benefit under title II of the Social Security Act. These will be reported on Form SSA-1099.</entry>
-</row>
-<row><entry><para><emphasis>  F1040 \ </emphasis>N266</para><para>Social Security income, self</para></entry>
-<entry>The part of any monthly benefit under title II of the Social Security Act. These will be reported on Form SSA-1099.</entry>
 </row>
 <row><entry><para><emphasis>  F1040 \ </emphasis>N260</para><para>State and local tax refunds</para></entry>
 <entry>Refund of state or local income tax refund (or credit or offset) which you deducted or took a credit for in an earlier year. You should receive a statement, Form 1099-G. Not reportable if you didn&rsquo;t itemize last year.</entry>
 </row>
-<row><entry><para><emphasis>  F1040 \ </emphasis>N269</para><para>Taxable fringe benefits</para></entry>
-<entry>Fringe benefits you receive in connection with the performance of your services are included in your gross income as compensation. Examples: Accident or Health Plan, Educational Assistance, Group-Term Life Insurance, Transportation (company car).</entry>
+<row><entry><para><emphasis>  F1040 \ </emphasis>N262</para><para>IRA contribution, self</para></entry>
+<entry>Contribution to a qualified IRA.  If you or your spouse are covered by a company retirement plan, this amount could be limited or eliminated.</entry>
+</row>
+<row><entry><para><emphasis>  F1040 \ </emphasis>N263</para><para>Keogh deduction, self</para></entry>
+<entry>Contributions to a Keogh or HR 10 plan of a sole proprietor or a partnership.</entry>
 </row>
 <row><entry><para><emphasis>  F1040 \ </emphasis>N264</para><para>Alimony paid</para></entry>
 <entry>Amounts payed as alimony or separate maintenance.  Note: child support is not considered alimony.</entry>
@@ -57,41 +48,23 @@
 <row><entry><para><emphasis>&lt; F1040 \ </emphasis>N265</para><para>Early withdrawal penalty</para></entry>
 <entry>Penalty on Early Withdrawal of Savings from CD&rsquo;s or similar instruments. This is reported on Form 1099-INT or Form 1099-OID.</entry>
 </row>
-<row><entry><para><emphasis>  F1040 \ </emphasis>N521</para><para>Federal estimated tax, quarterly</para></entry>
-<entry>The quarterly payments you made on your estimated Federal income tax (Form 1040-ES). Include any overpay from your previous year return that you applied to your estimated tax. NOTE: If a full year (Jan 1, YEAR to Dec 31, YEAR) is specified, <application>&app;</application> adjusts the date to Mar 1, YEAR to Feb 28, YEAR+1. Thus, the payment due Jan 15 is exported for the correct year.</entry>
+<row><entry><para><emphasis>  F1040 \ </emphasis>N266</para><para>Social Security income, self</para></entry>
+<entry>The part of any monthly benefit under title II of the Social Security Act. These will be reported on Form SSA-1099.</entry>
 </row>
-<row><entry><para><emphasis>  F1040 \ </emphasis>N613</para><para>Fed tax withheld, RR retire, self</para></entry>
-<entry>The amount of federal income taxes withheld from your part of tier I railroad retirement benefits, which are treated as a social security benefits.</entry>
-</row>
-<row><entry><para><emphasis>  F1040 \ </emphasis>N614</para><para>Fed tax withheld, RR retire, spouse</para></entry>
-<entry>The amount of federal income taxes withheld from your spouse&rsquo;s part of tier I railroad retirement benefits, which are treated as a social security benefits.</entry>
-</row>
-<row><entry><para><emphasis>  F1040 \ </emphasis>N611</para><para>Fed tax withheld, Social Security, self</para></entry>
-<entry>The amount of federal income taxes withheld from your part of any monthly benefit under title II of the Social Security Act.</entry>
-</row>
-<row><entry><para><emphasis>  F1040 \ </emphasis>N612</para><para>Fed tax withheld, Social Security, spouse</para></entry>
-<entry>The amount of federal income taxes withheld from your spouse&rsquo;s part of any monthly benefit under title II of the Social Security Act.</entry>
-</row>
-<row><entry><para><emphasis>  F1040 \ </emphasis>N482</para><para>IRA contrib., non-work spouse</para></entry>
-<entry>IRA contribution for a non-working spouse.</entry>
-</row>
-<row><entry><para><emphasis>  F1040 \ </emphasis>N262</para><para>IRA contribution, self</para></entry>
-<entry>Contribution to a qualified IRA.  If you or your spouse are covered by a company retirement plan, this amount could be limited or eliminated.</entry>
+<row><entry><para><emphasis>  F1040 \ </emphasis>N269</para><para>Taxable fringe benefits</para></entry>
+<entry>Fringe benefits you receive in connection with the performance of your services are included in your gross income as compensation. Examples: Accident or Health Plan, Educational Assistance, Group-Term Life Insurance, Transportation (company car).</entry>
 </row>
 <row><entry><para><emphasis>  F1040 \ </emphasis>N481</para><para>IRA contribution, spouse</para></entry>
 <entry>Contribution of a working spouse to a qualified IRA. If you or your spouse are covered by a company retirement plan, the deductible contribution could be limited or eliminated.</entry>
 </row>
-<row><entry><para><emphasis>  F1040 \ </emphasis>N263</para><para>Keogh deduction, self</para></entry>
-<entry>Contributions to a Keogh or HR 10 plan of a sole proprietor or a partnership.</entry>
+<row><entry><para><emphasis>  F1040 \ </emphasis>N482</para><para>IRA contrib., non-work spouse</para></entry>
+<entry>IRA contribution for a non-working spouse.</entry>
+</row>
+<row><entry><para><emphasis>  F1040 \ </emphasis>N483</para><para>Social Security inc., spouse</para></entry>
+<entry>Spouse&rsquo;s part of any monthly benefit under title II of the Social Security Act. These will be reported on Form SSA-1099.</entry>
 </row>
 <row><entry><para><emphasis>  F1040 \ </emphasis>N516</para><para>Keogh deduction, spouse</para></entry>
 <entry>Spouse Contributions to a Keogh or HR 10 plan of a sole proprietor or a partnership.</entry>
-</row>
-<row><entry><para><emphasis>  F1040 \ </emphasis>N608</para><para>Medical savings contribution, spouse</para></entry>
-<entry>Contributions made to your spouse&rsquo;s medical savings account that were not reported on their Form W-2.</entry>
-</row>
-<row><entry><para><emphasis>  F1040 \ </emphasis>N607</para><para>Medical savings contribution, self</para></entry>
-<entry>Contributions made to your medical savings account that were not reported on your Form W-2.</entry>
 </row>
 <row><entry><para><emphasis>  F1040 \ </emphasis>N517</para><para>SEP-IRA deduction, self</para></entry>
 <entry>Contributions made to a simplified employee pension plan (SEP-IRA).</entry>
@@ -99,11 +72,38 @@
 <row><entry><para><emphasis>  F1040 \ </emphasis>N518</para><para>SEP-IRA deduction, spouse</para></entry>
 <entry>Spouse contributions made to a simplified employee pension plan (SEP-IRA).</entry>
 </row>
+<row><entry><para><emphasis>  F1040 \ </emphasis>N519</para><para>RR retirement income, self</para></entry>
+<entry>The part of tier I railroad retirement benefits, which are treated as a social security benefits. These will be reported on Form RRB-1099.</entry>
+</row>
+<row><entry><para><emphasis>  F1040 \ </emphasis>N520</para><para>RR retirement inc., spouse</para></entry>
+<entry>Spouse&rsquo;s part of tier I railroad retirement benefits, which are treated as a social security benefits. These will be reported on Form RRB-1099.</entry>
+</row>
+<row><entry><para><emphasis>  F1040 \ </emphasis>N521</para><para>Federal estimated tax, quarterly</para></entry>
+<entry>The quarterly payments you made on your estimated Federal income tax (Form 1040-ES). Include any overpay from your previous year return that you applied to your estimated tax. NOTE: If a full year (Jan 1, YEAR to Dec 31, YEAR) is specified, <application>&app;</application> adjusts the date to Mar 1, YEAR to Feb 28, YEAR+1. Thus, the payment due Jan 15 is exported for the correct year.</entry>
+</row>
+<row><entry><para><emphasis>  F1040 \ </emphasis>N607</para><para>Medical savings contribution, self</para></entry>
+<entry>Contributions made to your medical savings account that were not reported on your Form W-2.</entry>
+</row>
+<row><entry><para><emphasis>  F1040 \ </emphasis>N608</para><para>Medical savings contribution, spouse</para></entry>
+<entry>Contributions made to your spouse&rsquo;s medical savings account that were not reported on their Form W-2.</entry>
+</row>
 <row><entry><para><emphasis>  F1040 \ </emphasis>N609</para><para>SIMPLE contribution, self</para></entry>
 <entry>Contributions made to your SIMPLE retirement plan that were not reported on your Form W-2.</entry>
 </row>
 <row><entry><para><emphasis>  F1040 \ </emphasis>N610</para><para>SIMPLE contribution, spouse</para></entry>
 <entry>Contributions made to your spouse&rsquo;s SIMPLE retirement plan that were not reported on your spouse&rsquo;s Form W-2.</entry>
+</row>
+<row><entry><para><emphasis>  F1040 \ </emphasis>N611</para><para>Fed tax withheld, Social Security, self</para></entry>
+<entry>The amount of federal income taxes withheld from your part of any monthly benefit under title II of the Social Security Act.</entry>
+</row>
+<row><entry><para><emphasis>  F1040 \ </emphasis>N612</para><para>Fed tax withheld, Social Security, spouse</para></entry>
+<entry>The amount of federal income taxes withheld from your spouse&rsquo;s part of any monthly benefit under title II of the Social Security Act.</entry>
+</row>
+<row><entry><para><emphasis>  F1040 \ </emphasis>N613</para><para>Fed tax withheld, RR retire, self</para></entry>
+<entry>The amount of federal income taxes withheld from your part of tier I railroad retirement benefits, which are treated as a social security benefits.</entry>
+</row>
+<row><entry><para><emphasis>  F1040 \ </emphasis>N614</para><para>Fed tax withheld, RR retire, spouse</para></entry>
+<entry>The amount of federal income taxes withheld from your spouse&rsquo;s part of tier I railroad retirement benefits, which are treated as a social security benefits.</entry>
 </row>
 <row><entry><para><emphasis>  F1040 \ </emphasis>N636</para><para>Student loan interest</para></entry>
 <entry>The amount of interest you paid this year on qualified student loans.</entry>
@@ -111,41 +111,29 @@
 <row><entry><para><emphasis>Help F1099-G \ </emphasis>H634</para><para>Form 1099-G - certain Government payments</para></entry>
 <entry>Form 1099-G is used to report certain government payments from federal, state, or local governments.</entry>
 </row>
-<row><entry><para><emphasis>  F1099-G \ </emphasis>N672</para><para>Qualified state tuition earnings</para></entry>
-<entry>Qualified state tuition program earnings you received this year.</entry>
-</row>
 <row><entry><para><emphasis>  F1099-G \ </emphasis>N260</para><para>State and local tax refunds</para></entry>
 <entry>Refund of state or local income tax refund (or credit or offset) which you deducted or took a credit for in an earlier year. You should receive a statement, Form 1099-G. Not reportable if you didn&rsquo;t itemize last year.</entry>
 </row>
 <row><entry><para><emphasis>  F1099-G \ </emphasis>N479</para><para>Unemployment compensation</para></entry>
 <entry>Total unemployment compensation paid to you this year. Reported on Form 1099-G.</entry>
 </row>
+<row><entry><para><emphasis>  F1099-G \ </emphasis>N605</para><para>Unemployment comp repaid</para></entry>
+<entry>If you received an overpayment of unemployment compensation this year or last and you repaid any of it this year, subtract the amount you repaid from the total amount you received.</entry>
+</row>
 <row><entry><para><emphasis>  F1099-G \ </emphasis>N606</para><para>Fed tax withheld, unemployment comp</para></entry>
 <entry>The amount of federal income taxes withheld from your unemployment compensation.</entry>
 </row>
-<row><entry><para><emphasis>  F1099-G \ </emphasis>N605</para><para>Unemployment comp repaid</para></entry>
-<entry>If you received an overpayment of unemployment compensation this year or last and you repaid any of it this year, subtract the amount you repaid from the total amount you received.</entry>
+<row><entry><para><emphasis>  F1099-G \ </emphasis>N672</para><para>Qualified state tuition earnings</para></entry>
+<entry>Qualified state tuition program earnings you received this year.</entry>
 </row>
 <row><entry><para><emphasis>Help F1099-MISC \ </emphasis>H553</para><para>Form 1099-MISC - MISCellaneous income</para></entry>
 <entry>Form 1099-MISC is used to report miscellaneous income received and direct sales of consumer goods for resale.</entry>
 </row>
-<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N562</para><para>Crop insurance proceeds</para></entry>
-<entry>The amount of crop insurance proceeds as the result of crop damage.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N559</para><para>Fishing boat proceeds</para></entry>
-<entry>Your share of all proceeds from the sale of a catch or the fair market value of a distribution in kind that you received as a crew member of a fishing boat.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N560</para><para>Medical/health payments</para></entry>
-<entry>The amount of payments received as a physician or other supplier or provider of medical or health care services. This includes payments made by medical and health care insurers under health, accident, and sickness insurance programs.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N561</para><para>Non employee compensation</para></entry>
-<entry>The amount of non-employee compensation received. This includes fees, commissions, prizes and awards for services performed, other forms of compensation for services you performed for a trade or business by which you are not employed.  Also include oil and gas payments for a working interest.</entry>
+<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N259</para><para>Prizes and awards</para></entry>
+<entry>The amount of prizes and awards that are not for services performed. Included is the fair market value of merchandise won on game shows.</entry>
 </row>
 <row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N557</para><para>Other income</para></entry>
 <entry>The amount of prizes and awards that are not for services performed. Included is the fair market value of merchandise won on game shows. Included is all punitive damages, any damages for nonphysical injuries or sickness, and any other taxable damages, Deceased employee&rsquo;s wages paid to estate or beneficiary.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N259</para><para>Prizes and awards</para></entry>
-<entry>The amount of prizes and awards that are not for services performed. Included is the fair market value of merchandise won on game shows.</entry>
 </row>
 <row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N555</para><para>Rents</para></entry>
 <entry>Amounts received for all types of rents, such as real estate rentals for office space, machine rentals, and pasture rentals.</entry>
@@ -156,32 +144,32 @@
 <row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N558</para><para>Federal tax withheld</para></entry>
 <entry>The amount of federal income tax withheld (backup withholding) from 1099-MISC income.</entry>
 </row>
+<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N559</para><para>Fishing boat proceeds</para></entry>
+<entry>Your share of all proceeds from the sale of a catch or the fair market value of a distribution in kind that you received as a crew member of a fishing boat.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N560</para><para>Medical/health payments</para></entry>
+<entry>The amount of payments received as a physician or other supplier or provider of medical or health care services. This includes payments made by medical and health care insurers under health, accident, and sickness insurance programs.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N561</para><para>Non employee compensation</para></entry>
+<entry>The amount of non-employee compensation received. This includes fees, commissions, prizes and awards for services performed, other forms of compensation for services you performed for a trade or business by which you are not employed.  Also include oil and gas payments for a working interest.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N562</para><para>Crop insurance proceeds</para></entry>
+<entry>The amount of crop insurance proceeds as the result of crop damage.</entry>
+</row>
 <row><entry><para><emphasis>^ F1099-MISC \ </emphasis>N563</para><para>State tax withheld</para></entry>
 <entry>The amount of state income tax withheld (state backup withholding) from 1099-MISC income.</entry>
 </row>
 <row><entry><para><emphasis>Help F1099=MSA \ </emphasis>H629</para><para>Form 1099-MSA Medical Savings Account</para></entry>
 <entry>Form 1099-MSA is used to report medical savings account distributions.</entry>
 </row>
-<row><entry><para><emphasis>  F1099-MSA \ </emphasis>N632</para><para>MSA earnings on excess contrib</para></entry>
-<entry>The earnings on any excess contributions you withdrew from an MSA by the due date of your income tax return. If you withdrew the excess, plus any earnings, by the due date of your income tax return, you must include the earnings in your income in the year you received the distribution even if you used it to pay qualified medical expenses.</entry>
-</row>
 <row><entry><para><emphasis>  F1099-MSA \ </emphasis>N631</para><para>MSA gross distribution</para></entry>
 <entry>The amount you received this year from a Medical Savings Account. The amount may have been a direct payment to the medical service provider or distributed to you.</entry>
 </row>
+<row><entry><para><emphasis>  F1099-MSA \ </emphasis>N632</para><para>MSA earnings on excess contrib</para></entry>
+<entry>The earnings on any excess contributions you withdrew from an MSA by the due date of your income tax return. If you withdrew the excess, plus any earnings, by the due date of your income tax return, you must include the earnings in your income in the year you received the distribution even if you used it to pay qualified medical expenses.</entry>
+</row>
 <row><entry><para><emphasis>Help F1099-R \ </emphasis>H473</para><para>Form 1099-R - Retirement distributions</para></entry>
 <entry>Form 1099-R is used to report taxable and non-taxable retirement distributions from retirement, pension, profit-sharing, or annuity plans. Use a separate Form 1099-R for each payer.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-R \ </emphasis>N623</para><para>SIMPLE total gross distribution</para></entry>
-<entry>The gross amount of a distribution received from a qualified SIMPLE pension plan.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-R \ </emphasis>N624</para><para>SIMPLE total taxable distribution</para></entry>
-<entry>The taxable amount of a distribution received from a qualified SIMPLE plan. This amount may be subject to a federal penalty of up to 25%.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-R \ </emphasis>N477</para><para>Total IRA gross distribution</para></entry>
-<entry>The gross amount of a distribution from a qualified Individual Retirement Arrangement (IRA) plan.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-R \ </emphasis>N478</para><para>Total IRA taxable distribution</para></entry>
-<entry>The taxable amount of a distribution from a qualified Individual Retirement Arrangement (IRA) plan.</entry>
 </row>
 <row><entry><para><emphasis>^ F1099-R \ </emphasis>N475</para><para>Total pension gross distribution</para></entry>
 <entry>The gross amount of a distribution from a qualified pension or annuity plan. Note: IRA distributions are not included here.</entry>
@@ -189,35 +177,62 @@
 <row><entry><para><emphasis>^ F1099-R \ </emphasis>N476</para><para>Total pension taxable distribution</para></entry>
 <entry>The taxable amount of a distribution from a qualified pension or annuity plan. Note: IRA distributions are not included here.</entry>
 </row>
-<row><entry><para><emphasis>^ F1099-R \ </emphasis>N532</para><para>IRA federal tax withheld</para></entry>
-<entry>The amount of federal income taxes withheld from your IRA distribution.</entry>
+<row><entry><para><emphasis>^ F1099-R \ </emphasis>N477</para><para>Total IRA gross distribution</para></entry>
+<entry>The gross amount of a distribution from a qualified Individual Retirement Arrangement (IRA) plan.</entry>
 </row>
-<row><entry><para><emphasis>^ F1099-R \ </emphasis>N534</para><para>IRA local tax withheld</para></entry>
-<entry>The amount of local income taxes withheld from your IRA distribution.</entry>
-</row>
-<row><entry><para><emphasis>^ F1099-R \ </emphasis>N533</para><para>IRA state tax withheld</para></entry>
-<entry>The amount of state income taxes withheld from your IRA distribution.</entry>
+<row><entry><para><emphasis>^ F1099-R \ </emphasis>N478</para><para>Total IRA taxable distribution</para></entry>
+<entry>The taxable amount of a distribution from a qualified Individual Retirement Arrangement (IRA) plan.</entry>
 </row>
 <row><entry><para><emphasis>^ F1099-R \ </emphasis>N529</para><para>Pension federal tax withheld</para></entry>
 <entry>The amount of federal income taxes withheld from your pension distribution.</entry>
 </row>
+<row><entry><para><emphasis>^ F1099-R \ </emphasis>N530</para><para>Pension state tax withheld</para></entry>
+<entry>The amount of state income taxes withheld from your pension distribution.</entry>
+</row>
 <row><entry><para><emphasis>^ F1099-R \ </emphasis>N531</para><para>Pension local tax withheld</para></entry>
 <entry>The amount of local income taxes withheld from your pension distribution.</entry>
 </row>
-<row><entry><para><emphasis>^ F1099-R \ </emphasis>N530</para><para>Pension state tax withheld</para></entry>
-<entry>The amount of state income taxes withheld from your pension distribution.</entry>
+<row><entry><para><emphasis>^ F1099-R \ </emphasis>N532</para><para>IRA federal tax withheld</para></entry>
+<entry>The amount of federal income taxes withheld from your IRA distribution.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-R \ </emphasis>N533</para><para>IRA state tax withheld</para></entry>
+<entry>The amount of state income taxes withheld from your IRA distribution.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-R \ </emphasis>N534</para><para>IRA local tax withheld</para></entry>
+<entry>The amount of local income taxes withheld from your IRA distribution.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-R \ </emphasis>N623</para><para>SIMPLE total gross distribution</para></entry>
+<entry>The gross amount of a distribution received from a qualified SIMPLE pension plan.</entry>
+</row>
+<row><entry><para><emphasis>^ F1099-R \ </emphasis>N624</para><para>SIMPLE total taxable distribution</para></entry>
+<entry>The taxable amount of a distribution received from a qualified SIMPLE plan. This amount may be subject to a federal penalty of up to 25%.</entry>
 </row>
 <row><entry><para><emphasis>^ F1099-R \ </emphasis>N625</para><para>SIMPLE federal tax withheld</para></entry>
 <entry>The amount of federal income taxes withheld from a SIMPLE distribution received.</entry>
 </row>
-<row><entry><para><emphasis>^ F1099-R \ </emphasis>N627</para><para>SIMPLE local tax withheld</para></entry>
-<entry>The amount of local income taxes withheld from a SIMPLE distribution received.</entry>
-</row>
 <row><entry><para><emphasis>^ F1099-R \ </emphasis>N626</para><para>SIMPLE state tax withheld</para></entry>
 <entry>The amount of state income taxes withheld from a SIMPLE distribution received.</entry>
 </row>
+<row><entry><para><emphasis>^ F1099-R \ </emphasis>N627</para><para>SIMPLE local tax withheld</para></entry>
+<entry>The amount of local income taxes withheld from a SIMPLE distribution received.</entry>
+</row>
 <row><entry><para><emphasis>Help F2106 \ </emphasis>H380</para><para>employee business expenses</para></entry>
 <entry>Form 2106 is used to deduct employee business expenses. You must file this form if you were reimbursed by your employer or claim job-related travel, transportation, meal, or entertainment expenses. Use a separate Form 2106 for your spouse&rsquo;s expenses.</entry>
+</row>
+<row><entry><para><emphasis>  F2106 \ </emphasis>N381</para><para>Education expenses</para></entry>
+<entry>Cost of tuition, books, supplies, laboratory fees, and similar items, and certain transportation costs if the education maintains or improves skills required in your present work or is required by your employer or the law to keep your salary, status, or job, and the requirement serves a business purpose of your employer. Expenses are not deductible if they are needed to meet the minimum educational requirements to qualify you in your work or business or will lead to qualifying you in a new trade or business.</entry>
+</row>
+<row><entry><para><emphasis>  F2106 \ </emphasis>N382</para><para>Automobile expenses</para></entry>
+<entry>Total annual expenses for gasoline, oil, repairs, insurance, tires, license plates, or similar items.</entry>
+</row>
+<row><entry><para><emphasis>  F2106 \ </emphasis>N384</para><para>Local transportation expenses</para></entry>
+<entry>Local transportation expenses are the expenses of getting from one workplace to another when you are not traveling away from home. They include the cost of transportation by air, rail, bus, taxi, and the cost of using your car. Generally, the cost of commuting to and from your regular place of work is not deductible.</entry>
+</row>
+<row><entry><para><emphasis>  F2106 \ </emphasis>N385</para><para>Other business expenses</para></entry>
+<entry>Other job-related expenses, including expenses for business gifts, trade publications, etc.</entry>
+</row>
+<row><entry><para><emphasis>  F2106 \ </emphasis>N386</para><para>Meal/entertainment expenses</para></entry>
+<entry>Allowable meals and entertainment expense, including meals while away from your tax home overnight and other business meals and entertainment.</entry>
 </row>
 <row><entry><para><emphasis>  F2106 \ </emphasis>N387</para><para>Reimb. business expenses (non-meal/ent.)</para></entry>
 <entry>Reimbursement for business expenses from your employer that is NOT included on your Form W-2. Note: meals and entertainment are NOT included here.</entry>
@@ -225,29 +240,14 @@
 <row><entry><para><emphasis>  F2106 \ </emphasis>N388</para><para>Reimb. meal/entertainment expenses</para></entry>
 <entry>Reimbursement for meal and entertainment expenses from your employer that is NOT included on your Form W-2.</entry>
 </row>
-<row><entry><para><emphasis>  F2106 \ </emphasis>N382</para><para>Automobile expenses</para></entry>
-<entry>Total annual expenses for gasoline, oil, repairs, insurance, tires, license plates, or similar items.</entry>
-</row>
-<row><entry><para><emphasis>  F2106 \ </emphasis>N381</para><para>Education expenses</para></entry>
-<entry>Cost of tuition, books, supplies, laboratory fees, and similar items, and certain transportation costs if the education maintains or improves skills required in your present work or is required by your employer or the law to keep your salary, status, or job, and the requirement serves a business purpose of your employer. Expenses are not deductible if they are needed to meet the minimum educational requirements to qualify you in your work or business or will lead to qualifying you in a new trade or business.</entry>
-</row>
-<row><entry><para><emphasis>  F2106 \ </emphasis>N391</para><para>Employee home office expenses</para></entry>
-<entry>Your use of the business part of your home must be: exclusive, regular, for your trade or business, AND The business part of your home must be one of the following: your principal place of business, a place where you meet or deal with patients, clients, or customers in the normal course of your trade or business, or a separate structure (not attached to your home) you use in connection with your trade or business. Additionally, Your business use must be for the convenience of your employer, and You do not rent all or part of your home to your employer and use the rented portion to perform services as an employee. See IRS Pub 587.</entry>
-</row>
 <row><entry><para><emphasis>  F2106 \ </emphasis>N389</para><para>Job seeking expenses</para></entry>
 <entry>Fees to employment agencies and other costs to look for a new job in your present occupation, even if you do not get a new job.</entry>
 </row>
-<row><entry><para><emphasis>  F2106 \ </emphasis>N384</para><para>Local transportation expenses</para></entry>
-<entry>Local transportation expenses are the expenses of getting from one workplace to another when you are not traveling away from home. They include the cost of transportation by air, rail, bus, taxi, and the cost of using your car. Generally, the cost of commuting to and from your regular place of work is not deductible.</entry>
-</row>
-<row><entry><para><emphasis>  F2106 \ </emphasis>N386</para><para>Meal/entertainment expenses</para></entry>
-<entry>Allowable meals and entertainment expense, including meals while away from your tax home overnight and other business meals and entertainment.</entry>
-</row>
-<row><entry><para><emphasis>  F2106 \ </emphasis>N385</para><para>Other business expenses</para></entry>
-<entry>Other job-related expenses, including expenses for business gifts, trade publications, etc.</entry>
-</row>
 <row><entry><para><emphasis>  F2106 \ </emphasis>N390</para><para>Special clothing expenses</para></entry>
 <entry>cost and upkeep of work clothes, if you must wear them as a condition of your employment, and the clothes are not suitable for everyday wear. Include the cost of protective clothing required in your work, such as safety shoes or boots, safety glasses, hard hats, and work gloves.</entry>
+</row>
+<row><entry><para><emphasis>  F2106 \ </emphasis>N391</para><para>Employee home office expenses</para></entry>
+<entry>Your use of the business part of your home must be: exclusive, regular, for your trade or business, AND The business part of your home must be one of the following: your principal place of business, a place where you meet or deal with patients, clients, or customers in the normal course of your trade or business, or a separate structure (not attached to your home) you use in connection with your trade or business. Additionally, Your business use must be for the convenience of your employer, and You do not rent all or part of your home to your employer and use the rented portion to perform services as an employee. See IRS Pub 587.</entry>
 </row>
 <row><entry><para><emphasis>  F2106 \ </emphasis>N383</para><para>Travel (away from home)</para></entry>
 <entry>Travel expenses are those incurred while traveling away from home for your employer. The cost of getting to and from your business destination (air, rail, bus, car, etc.), taxi fares, baggage charges, and cleaning and laundry expenses. Note: meal and entertainment expenses are not included here.</entry>
@@ -282,41 +282,41 @@
 <row><entry><para><emphasis>  F4684 \ </emphasis>N416</para><para>FMV after casualty</para></entry>
 <entry>The fair market value (FMV) is the price at which the property would change hands between a willing buyer and seller, each having knowledge of the relevant facts. The FMV after a theft is zero if the property is not recovered. The FMV is generally determined by competent appraisal.</entry>
 </row>
-<row><entry><para><emphasis>  F4684 \ </emphasis>N415</para><para>FMV before casualty</para></entry>
-<entry>The fair market value (FMV) is the price at which the property would change hands between a willing buyer and seller, each having knowledge of the relevant facts. FMV is generally determined by competent appraisal.</entry>
+<row><entry><para><emphasis>  F4684 \ </emphasis>N413</para><para>Basis of casualty property</para></entry>
+<entry>Cost or other basis usually means original cost plus improvements. Subtract any postponed gain from the sale of a previous main home. Special rules apply to property received as a gift or inheritance. See Pub  551, Basis of Assets, for details.</entry>
 </row>
 <row><entry><para><emphasis>  F4684 \ </emphasis>N414</para><para>Insurance/reimbursement</para></entry>
 <entry>The amount of insurance or other reimbursement you received expect to receive.</entry>
 </row>
-<row><entry><para><emphasis>  F4684 \ </emphasis>N413</para><para>Basis of casualty property</para></entry>
-<entry>Cost or other basis usually means original cost plus improvements. Subtract any postponed gain from the sale of a previous main home. Special rules apply to property received as a gift or inheritance. See Pub  551, Basis of Assets, for details.</entry>
+<row><entry><para><emphasis>  F4684 \ </emphasis>N415</para><para>FMV before casualty</para></entry>
+<entry>The fair market value (FMV) is the price at which the property would change hands between a willing buyer and seller, each having knowledge of the relevant facts. FMV is generally determined by competent appraisal.</entry>
 </row>
 <row><entry><para><emphasis>Help F4835 \ </emphasis>H569</para><para>Form 4835 - farm rental income</para></entry>
 <entry>Form 4835 is used to report farm rental income received as a share of crops or livestock produced by your tenant if you did not materially participate in the operation or management of the farm.  Use a different copy of Form 4835 for each farm rented.</entry>
 </row>
-<row><entry><para><emphasis>  F4835 \ </emphasis>N573</para><para>Agricultural program payments</para></entry>
-<entry>Government payments received for: price support payments, market gain from the repayment of a secured Commodity Credit Corporation (CCC) loan for less than the original loan amount, diversion payments, cost-share payments (sight drafts), payments in the form of materials (such as fertilizer or lime) or services (such as grading or building dams). Reported on Form 1099-G.</entry>
-</row>
-<row><entry><para><emphasis>  F4835 \ </emphasis>N575</para><para>CCC loans forfeited/repaid</para></entry>
-<entry>The full amount forfeited or repaid with certificates, even if you reported the loan proceeds as income.  See IRS Pub 225.</entry>
-</row>
-<row><entry><para><emphasis>  F4835 \ </emphasis>N574</para><para>CCC loans reported/election</para></entry>
-<entry>Generally, you do not report CCC loan proceeds as income. However, if you pledge part or all of your production to secure a CCC loan, you may elect to report the loan proceeds as income in the year you receive them, instead of the year you sell the crop.</entry>
-</row>
-<row><entry><para><emphasis>  F4835 \ </emphasis>N577</para><para>Crop insurance proceeds deferred</para></entry>
-<entry>If you use the cash method of accounting and receive crop insurance proceeds in the same tax year in which the crops are damaged, you can choose to postpone reporting the proceeds as income until the following tax year. A statement must also be attached to your return.  See IRS Pub 225.</entry>
-</row>
-<row><entry><para><emphasis>  F4835 \ </emphasis>N576</para><para>Crop insurance proceeds received</para></entry>
-<entry>You generally include crop insurance proceeds in the year you receive them. Treat as crop insurance proceeds the crop disaster payments you receive from the federal government.</entry>
-</row>
-<row><entry><para><emphasis>  F4835 \ </emphasis>N578</para><para>Other income</para></entry>
-<entry>Illegal Federal irrigation subsidies, bartering income, income from discharge of indebtedness, state gasoline or fuel tax refund, the gain or loss on the sale of commodity futures contracts, etc.</entry>
+<row><entry><para><emphasis>  F4835 \ </emphasis>N572</para><para>Total cooperative distributions</para></entry>
+<entry>Distributions received from a cooperative. This includes patronage dividends, non patronage distributions, per-unit retain allocations, and redemption of non qualified notices and per unit retain allocations. Reported on Form 1099-PATR.</entry>
 </row>
 <row><entry><para><emphasis>  F4835 \ </emphasis>N571</para><para>Sale of livestock/produce</para></entry>
 <entry>Income you received from livestock, produce, grains, and other crops based on production. Under both the cash and the accrual methods of reporting, you must report livestock or crop share rentals received in the year you convert them into money or its equivalent.</entry>
 </row>
-<row><entry><para><emphasis>  F4835 \ </emphasis>N572</para><para>Total cooperative distributions</para></entry>
-<entry>Distributions received from a cooperative. This includes patronage dividends, non patronage distributions, per-unit retain allocations, and redemption of non qualified notices and per unit retain allocations. Reported on Form 1099-PATR.</entry>
+<row><entry><para><emphasis>  F4835 \ </emphasis>N573</para><para>Agricultural program payments</para></entry>
+<entry>Government payments received for: price support payments, market gain from the repayment of a secured Commodity Credit Corporation (CCC) loan for less than the original loan amount, diversion payments, cost-share payments (sight drafts), payments in the form of materials (such as fertilizer or lime) or services (such as grading or building dams). Reported on Form 1099-G.</entry>
+</row>
+<row><entry><para><emphasis>  F4835 \ </emphasis>N574</para><para>CCC loans reported/election</para></entry>
+<entry>Generally, you do not report CCC loan proceeds as income. However, if you pledge part or all of your production to secure a CCC loan, you may elect to report the loan proceeds as income in the year you receive them, instead of the year you sell the crop.</entry>
+</row>
+<row><entry><para><emphasis>  F4835 \ </emphasis>N575</para><para>CCC loans forfeited/repaid</para></entry>
+<entry>The full amount forfeited or repaid with certificates, even if you reported the loan proceeds as income.  See IRS Pub 225.</entry>
+</row>
+<row><entry><para><emphasis>  F4835 \ </emphasis>N576</para><para>Crop insurance proceeds received</para></entry>
+<entry>You generally include crop insurance proceeds in the year you receive them. Treat as crop insurance proceeds the crop disaster payments you receive from the federal government.</entry>
+</row>
+<row><entry><para><emphasis>  F4835 \ </emphasis>N577</para><para>Crop insurance proceeds deferred</para></entry>
+<entry>If you use the cash method of accounting and receive crop insurance proceeds in the same tax year in which the crops are damaged, you can choose to postpone reporting the proceeds as income until the following tax year. A statement must also be attached to your return.  See IRS Pub 225.</entry>
+</row>
+<row><entry><para><emphasis>  F4835 \ </emphasis>N578</para><para>Other income</para></entry>
+<entry>Illegal Federal irrigation subsidies, bartering income, income from discharge of indebtedness, state gasoline or fuel tax refund, the gain or loss on the sale of commodity futures contracts, etc.</entry>
 </row>
 <row><entry><para><emphasis>  F4835 \ </emphasis>N579</para><para>Car and truck expenses</para></entry>
 <entry>The business portion of car or truck expenses, such as, for gasoline, oil, repairs, insurance, tires, license plates, etc.</entry>
@@ -357,17 +357,14 @@
 <row><entry><para><emphasis>  F4835 \ </emphasis>N591</para><para>Labor hired</para></entry>
 <entry>The amounts you paid for farm labor. Do not include amounts paid to yourself.  Count the cost of boarding farm labor but not the value of any products they used from the farm. Count only what you paid house-hold help to care for farm laborers.</entry>
 </row>
-<row><entry><para><emphasis>  F4835 \ </emphasis>N602</para><para>Other farm expenses</para></entry>
-<entry>Include all ordinary and necessary farm rental expenses not deducted elsewhere on Form 4835, such as advertising, office supplies, etc. Do not include fines or penalties paid to a government for violating any law.</entry>
-</row>
 <row><entry><para><emphasis>  F4835 \ </emphasis>N592</para><para>Pension/profit-sharing plans</para></entry>
 <entry>Enter your deduction for contributions to employee pension, profit-sharing, or annuity plans. If the plan included you as a self-employed person, see the instructions for Schedule C (Form 1040).</entry>
 </row>
-<row><entry><para><emphasis>  F4835 \ </emphasis>N594</para><para>Rent/lease land, animals</para></entry>
-<entry>Amounts paid to rent or lease property such as pasture or farm land.</entry>
-</row>
 <row><entry><para><emphasis>  F4835 \ </emphasis>N593</para><para>Rent/lease vehicles, equip.</para></entry>
 <entry>The business portion of your rental cost, for rented or leased vehicles, machinery, or equipment. But if you leased a vehicle for a term of 30 days or more, you may have to reduce your deduction by an inclusion amount. For details, see the instructions for Schedule C (Form 1040).</entry>
+</row>
+<row><entry><para><emphasis>  F4835 \ </emphasis>N594</para><para>Rent/lease land, animals</para></entry>
+<entry>Amounts paid to rent or lease property such as pasture or farm land.</entry>
 </row>
 <row><entry><para><emphasis>  F4835 \ </emphasis>N595</para><para>Repairs and maintenance</para></entry>
 <entry>Amounts you paid for repairs and maintenance of farm buildings, machinery, and equipment. You can also include what you paid for tools of short life or minimal cost, such as shovels and rakes.</entry>
@@ -390,6 +387,9 @@
 <row><entry><para><emphasis>  F4835 \ </emphasis>N601</para><para>Vet, breeding, medicine</para></entry>
 <entry>The costs of veterinary services, medicine and breeding fees.</entry>
 </row>
+<row><entry><para><emphasis>  F4835 \ </emphasis>N602</para><para>Other farm expenses</para></entry>
+<entry>Include all ordinary and necessary farm rental expenses not deducted elsewhere on Form 4835, such as advertising, office supplies, etc. Do not include fines or penalties paid to a government for violating any law.</entry>
+</row>
 <row><entry><para><emphasis>Help F4952 \ </emphasis>H425</para><para>Form 4952 - investment interest</para></entry>
 <entry>Form 4952 is used to compute the amount of investment interest expense deductible for the current year and the amount, if any, to carry forward to future years.</entry>
 </row>
@@ -399,38 +399,38 @@
 <row><entry><para><emphasis>Help F6252 \ </emphasis>H427</para><para>Form 6252 - income from casual sales</para></entry>
 <entry>Form 6252 is used to report income from casual sales of real or personal property when you will receive any payments in a tax year after the year of sale (i.e., installment sale).</entry>
 </row>
+<row><entry><para><emphasis>  F6252 \ </emphasis>N428</para><para>Selling price</para></entry>
+<entry>Enter the total of any money, face amount of the installment obligation, and the FMV of other property that you received or will receive in exchange for the property sold.</entry>
+</row>
 <row><entry><para><emphasis>  F6252 \ </emphasis>N429</para><para>Debt assumed by buyer</para></entry>
 <entry>Enter only mortgages or other debts the buyer assumed from the seller or took the property subject to. Do not include new mortgages the buyer gets from a bank, the seller, or other sources.</entry>
 </row>
 <row><entry><para><emphasis>  F6252 \ </emphasis>N431</para><para>Depreciation allowed</para></entry>
 <entry>Enter all depreciation or amortization you deducted or should have deducted from the date of purchase until the date of sale. Add any section 179 expense deduction.  Several other adjustments are allowed, See Form 6252 instructions.</entry>
 </row>
-<row><entry><para><emphasis>  F6252 \ </emphasis>N435</para><para>Payments received prior years</para></entry>
-<entry>Enter all money and the fair market value (FMV) of property you received before this tax year from the sale. Include allocable installment income and any other deemed payments from prior years. Do not include interest whether stated or unstated.</entry>
+<row><entry><para><emphasis>  F6252 \ </emphasis>N432</para><para>Expenses of sale</para></entry>
+<entry>Enter sales commissions, advertising expenses, attorney and legal fees, etc., in selling the property.</entry>
 </row>
 <row><entry><para><emphasis>  F6252 \ </emphasis>N434</para><para>Payments received this year</para></entry>
 <entry>Enter all money and the fair market value (FMV) of any property you received in this tax year. Include as payments any amount withheld to pay off a mortgage or other debt, such as broker and legal fees. Do not include interest whether stated or unstated.</entry>
 </row>
-<row><entry><para><emphasis>  F6252 \ </emphasis>N428</para><para>Selling price</para></entry>
-<entry>Enter the total of any money, face amount of the installment obligation, and the FMV of other property that you received or will receive in exchange for the property sold.</entry>
-</row>
-<row><entry><para><emphasis>  F6252 \ </emphasis>N432</para><para>Expenses of sale</para></entry>
-<entry>Enter sales commissions, advertising expenses, attorney and legal fees, etc., in selling the property.</entry>
+<row><entry><para><emphasis>  F6252 \ </emphasis>N435</para><para>Payments received prior years</para></entry>
+<entry>Enter all money and the fair market value (FMV) of property you received before this tax year from the sale. Include allocable installment income and any other deemed payments from prior years. Do not include interest whether stated or unstated.</entry>
 </row>
 <row><entry><para><emphasis>Help F8815 \ </emphasis>H441</para><para>Form 8815 - EE U.S. savings bonds sold for education</para></entry>
 <entry>Form 8815 is used to compute the amount of interest you may exclude if you cashed series EE U.S. savings bonds this year that were issued after 1989 to pay for qualified higher education costs.</entry>
 </row>
-<row><entry><para><emphasis>  F8815 \ </emphasis>N444</para><para>EE US savings bonds proceeds</para></entry>
-<entry>Enter the total proceeds (principal and interest) from all series EE and I U.S. savings bonds issued after 1989 that you cashed during this tax year.</entry>
+<row><entry><para><emphasis>  F8815 \ </emphasis>N442</para><para>Qualified higher education expenses</para></entry>
+<entry>Qualified higher education expenses include tuition and fees required for the enrollment or attendance of the person(s). Do not include expenses for room and board, or courses involving sports, games, or hobbies that are not part of a degree or certificate granting program.</entry>
 </row>
 <row><entry><para><emphasis>  F8815 \ </emphasis>N443</para><para>Nontaxable education benefits</para></entry>
 <entry>Nontaxable educational benefits. These benefits include: Scholarship or fellowship grants excludable from income under section 117; Veterans&rsquo; educational assistance benefits; Employer-provided educational assistance benefits that are not included in box 1 of your W-2 form(s); Any other payments (but not gifts, bequests, or inheritances) for educational expenses that are exempt from income tax by any U.S. law. Do not include nontaxable educational benefits paid directly to, or by, the educational institution.</entry>
 </row>
+<row><entry><para><emphasis>  F8815 \ </emphasis>N444</para><para>EE US savings bonds proceeds</para></entry>
+<entry>Enter the total proceeds (principal and interest) from all series EE and I U.S. savings bonds issued after 1989 that you cashed during this tax year.</entry>
+</row>
 <row><entry><para><emphasis>  F8815 \ </emphasis>N445</para><para>Post-89 EE bond face value</para></entry>
 <entry>The face value of all post-1989 series EE bonds cashed this tax year.</entry>
-</row>
-<row><entry><para><emphasis>  F8815 \ </emphasis>N442</para><para>Qualified higher education expenses</para></entry>
-<entry>Qualified higher education expenses include tuition and fees required for the enrollment or attendance of the person(s). Do not include expenses for room and board, or courses involving sports, games, or hobbies that are not part of a degree or certificate granting program.</entry>
 </row>
 <row><entry><para><emphasis>Help F8863 \ </emphasis>H639</para><para>Form 8863 - Hope and Lifetime Learning education credits</para></entry>
 <entry>Form 8863 is used to compute the Hope and Lifetime Learning education credits. IRS rules are stringent for these credits.  Refer to IRS Publication 970 for more information.</entry>
@@ -447,14 +447,11 @@
 <row><entry><para><emphasis>  F8829 \ </emphasis>N537</para><para>Deductible mortgage interest</para></entry>
 <entry>The total amount of mortgage interest that would be deductible whether or not you used your home for business (i.e., amounts allowable as itemized deductions on Schedule A, Form 1040). Form 8829 computes the deductible business portion.</entry>
 </row>
-<row><entry><para><emphasis>  F8829 \ </emphasis>N539</para><para>Insurance</para></entry>
-<entry>The total amount of insurance paid for your home, in which an area or room is used regularly and exclusively for business. Form 8829 computes the deductible business portion.</entry>
-</row>
-<row><entry><para><emphasis>  F8829 \ </emphasis>N542</para><para>Other expenses</para></entry>
-<entry>If you rent rather than own your home, include rent paid for your home, in which an area or room is used regularly and exclusively for business. Form 8829 computes the deductible business portion.</entry>
-</row>
 <row><entry><para><emphasis>  F8829 \ </emphasis>N538</para><para>Real estate taxes</para></entry>
 <entry>The total amount of real estate taxes that would be deductible whether or not you used your home for business (i.e., amounts allowable as itemized deductions on Schedule A, Form 1040). Form 8829 computes the deductible business portion.</entry>
+</row>
+<row><entry><para><emphasis>  F8829 \ </emphasis>N539</para><para>Insurance</para></entry>
+<entry>The total amount of insurance paid for your home, in which an area or room is used regularly and exclusively for business. Form 8829 computes the deductible business portion.</entry>
 </row>
 <row><entry><para><emphasis>  F8829 \ </emphasis>N540</para><para>Repairs and maintenance</para></entry>
 <entry>The total amount of repairs and maintenance paid for your home, in which an area or room is used regularly and exclusively for business. Form 8829 computes the deductible business portion.</entry>
@@ -462,23 +459,26 @@
 <row><entry><para><emphasis>  F8829 \ </emphasis>N541</para><para>Utilities</para></entry>
 <entry>The total amount of utilities paid for your home, in which an area or room is used regularly and exclusively for business.  Form 8829 computes the deductible business portion.</entry>
 </row>
+<row><entry><para><emphasis>  F8829 \ </emphasis>N542</para><para>Other expenses</para></entry>
+<entry>If you rent rather than own your home, include rent paid for your home, in which an area or room is used regularly and exclusively for business. Form 8829 computes the deductible business portion.</entry>
+</row>
 <row><entry><para><emphasis>Help F8839 \ </emphasis>H617</para><para>Form 8839 - adoption expenses</para></entry>
 <entry>Form 8839 is used to report qualified adoption expenses.</entry>
 </row>
 <row><entry><para><emphasis>  F8839 \ </emphasis>N618</para><para>Adoption fees</para></entry>
 <entry>Adoption fees that are reasonable and necessary, directly related to, and for the principal purpose of, the legal adoption of an eligible child.</entry>
 </row>
-<row><entry><para><emphasis>  F8839 \ </emphasis>N620</para><para>Attorney fees</para></entry>
-<entry>Attorney fees that are reasonable and necessary, directly related to, and for the principal purpose of, the legal adoption of an eligible child.</entry>
-</row>
 <row><entry><para><emphasis>  F8839 \ </emphasis>N619</para><para>Court costs</para></entry>
 <entry>Court costs that are reasonable and necessary, directly related to, and for the principal purpose of, the legal adoption of an eligible child.</entry>
 </row>
-<row><entry><para><emphasis>  F8839 \ </emphasis>N622</para><para>Other expenses</para></entry>
-<entry>Other expenses that are reasonable and necessary, directly related to, and for the principal purpose of, the legal adoption of an eligible child.</entry>
+<row><entry><para><emphasis>  F8839 \ </emphasis>N620</para><para>Attorney fees</para></entry>
+<entry>Attorney fees that are reasonable and necessary, directly related to, and for the principal purpose of, the legal adoption of an eligible child.</entry>
 </row>
 <row><entry><para><emphasis>  F8839 \ </emphasis>N621</para><para>Traveling expenses</para></entry>
 <entry>Traveling expenses (including meals and lodging) while away from home, directly related to, and for the principal purpose of, the legal adoption of an eligible child.</entry>
+</row>
+<row><entry><para><emphasis>  F8839 \ </emphasis>N622</para><para>Other expenses</para></entry>
+<entry>Other expenses that are reasonable and necessary, directly related to, and for the principal purpose of, the legal adoption of an eligible child.</entry>
 </row>
 <row><entry><para><emphasis>  Home Sale \ </emphasis>N392</para><para>Home Sale worksheets (was F2119)</para></entry>
 <entry>Home Sale worksheets (replaces Form 2119) are used to report the sale of your personal residence. See IRS Pub 523.</entry>
@@ -486,52 +486,57 @@
 <row><entry><para><emphasis>  Home Sale \ </emphasis>N393</para><para>Selling price of old home</para></entry>
 <entry>The selling price is the total amount you receive for your home. It includes money, all notes, mortgages, or other debts assumed by the buyer as part of the sale, and the fair market value of any other property or any services you receive. Reported on Form 1099-S.</entry>
 </row>
-<row><entry><para><emphasis>  Home Sale \ </emphasis>N392</para><para>Home Sale worksheets (was F2119)</para></entry>
-<entry>Home Sale worksheets (replaces Form 2119) are used to report the sale of your personal residence. See IRS Pub 523.</entry>
-</row>
-<row><entry><para><emphasis>  Home Sale \ </emphasis>N397</para><para>Cost of new home</para></entry>
-<entry>The cost of your new home includes costs incurred within the replacement period (beginning 2 years before and ending 2 years after the date of sale) for the following items: Buying or building the home; Rebuilding the home; and Capital improvements or additions.</entry>
-</row>
 <row><entry><para><emphasis>  Home Sale \ </emphasis>N394</para><para>Expense of sale</para></entry>
 <entry>Selling expenses include commissions, advertising fees, legal fees, title insurance, and loan charges paid by the seller, such as loan placement fees or "points."</entry>
 </row>
 <row><entry><para><emphasis>  Home Sale \ </emphasis>N396</para><para>Fixing-up expenses</para></entry>
 <entry>Fixing-up expenses are decorating and repair costs that you paid to sell your old home. For example, the costs of painting the home, planting flowers, and replacing broken windows are fixing-up expenses. Fixing-up expenses must meet all the following conditions. The expenses: Must be for work done during the 90-day period ending on the day you sign the contract of sale with the buyer; Must be paid no later than 30 days after the date of sale; Cannot be deductible in arriving at your taxable in-come; Must not be used in figuring the amount realized; and Must not be capital expenditures or improvements.</entry>
 </row>
+<row><entry><para><emphasis>  Home Sale \ </emphasis>N397</para><para>Cost of new home</para></entry>
+<entry>The cost of your new home includes costs incurred within the replacement period (beginning 2 years before and ending 2 years after the date of sale) for the following items: Buying or building the home; Rebuilding the home; and Capital improvements or additions.</entry>
+</row>
 <row><entry><para><emphasis>Help Sched A \ </emphasis>H270</para><para>Schedule A - itemized deductions</para></entry>
 <entry>Schedule A is used to report your itemized deductions.</entry>
 </row>
-<row><entry><para><emphasis>  Sched A \ </emphasis>N280</para><para>Cash charity contributions</para></entry>
-<entry>Contributions or gifts by cash or check you gave to organizations that are religious, charitable, educational, scientific, or literary in purpose. You may also deduct what you gave to organizations that work to prevent cruelty to children or animals. For donations of $250 or more, you must have a statement from the charitable organization showing the amount donated and the value of goods or services you received.</entry>
-</row>
-<row><entry><para><emphasis>  Sched A \ </emphasis>N484</para><para>Doctors, dentists, hospitals</para></entry>
-<entry>Insurance premiums for medical and dental care, medical doctors, dentists, eye doctors, surgeons, X-ray, laboratory services, hospital care, etc. See IRS Pub 502.</entry>
+<row><entry><para><emphasis>  Sched A \ </emphasis>N271</para><para>Subscriptions</para></entry>
+<entry>Amounts paid for subscriptions to magazines or services that are directly related to the production or collection of taxable income.  (example: subscriptions to investment publications, stock newsletters, etc.).</entry>
 </row>
 <row><entry><para><emphasis>  Sched A \ </emphasis>N272</para><para>Gambling losses</para></entry>
 <entry>Gambling losses, but only to the extent of gambling winnings reported on Form 1040. Note: not subject to the 2% AGI of limitation.</entry>
 </row>
-<row><entry><para><emphasis>  Sched A \ </emphasis>N545</para><para>Home mortgage interest (no 1098)</para></entry>
-<entry>Home mortgage interest paid, for which you did not receive a Form 1098 from the recipient. The interest could be on a first or second mortgage, home equity loan, or refinanced mortgage.</entry>
+<row><entry><para><emphasis>  Sched A \ </emphasis>N273</para><para>Medicine and drugs</para></entry>
+<entry>Prescription medicines, eyeglasses, contact lenses, hearing aids. Over-the-counter medicines are not deductible.</entry>
 </row>
-<row><entry><para><emphasis>  Sched A \ </emphasis>N283</para><para>Home mortgage interest (1098)</para></entry>
-<entry>Home mortgage interest and points reported to you on Form 1098. The interest could be on a first or second mortgage, home equity loan, or refinanced mortgage.</entry>
+<row><entry><para><emphasis>  Sched A \ </emphasis>N274</para><para>Medical travel and lodging</para></entry>
+<entry>Lodging expenses while away from home to receive medical care in a hospital or a medical care facility related to a hospital. Do not include more than $50 a night for each eligible person. Ambulance service and other travel costs to get medical care.</entry>
+</row>
+<row><entry><para><emphasis>  Sched A \ </emphasis>N275</para><para>State income taxes</para></entry>
+<entry>State income taxes paid this year for a prior year. Include any part of a prior year refund that you chose to have credited to this years state income taxes.</entry>
+</row>
+<row><entry><para><emphasis>  Sched A \ </emphasis>N276</para><para>Real estate taxes</para></entry>
+<entry>Include taxes (state, local, or foreign) you paid on real estate you own that was not used for business, but only if the taxes are based on the assessed value of the property. Do not include taxes charged for improvements that tend to increase the value of your property (for example, an assessment to build a new sidewalk).</entry>
+</row>
+<row><entry><para><emphasis>  Sched A \ </emphasis>N277</para><para>Other taxes</para></entry>
+<entry>Other taxes paid not included under state and local income taxes, real estate taxes, or personal property taxes. You may want to take a credit for the foreign tax instead of a deduction.</entry>
+</row>
+<row><entry><para><emphasis>  Sched A \ </emphasis>N280</para><para>Cash charity contributions</para></entry>
+<entry>Contributions or gifts by cash or check you gave to organizations that are religious, charitable, educational, scientific, or literary in purpose. You may also deduct what you gave to organizations that work to prevent cruelty to children or animals. For donations of $250 or more, you must have a statement from the charitable organization showing the amount donated and the value of goods or services you received.</entry>
+</row>
+<row><entry><para><emphasis>  Sched A \ </emphasis>N281</para><para>Tax preparation fees</para></entry>
+<entry>Fees you paid for preparation of your tax return, including fees paid for filing your return electronically.</entry>
 </row>
 <row><entry><para><emphasis>  Sched A \ </emphasis>N282</para><para>Investment management fees</para></entry>
 <entry>Investment interest is interest paid on money you borrowed that is allocable to property held for investment. It does not include any interest allocable to passive activities or to securities that generate tax-exempt income.
 </entry>
 </row>
-<row><entry><para><emphasis>  Sched A \ </emphasis>N544</para><para>Local income taxes</para></entry>
-<entry>Local income taxes that were not withheld from your salary, such as local income taxes you paid this year for a prior year.
-</entry>
+<row><entry><para><emphasis>  Sched A \ </emphasis>N283</para><para>Home mortgage interest (1098)</para></entry>
+<entry>Home mortgage interest and points reported to you on Form 1098. The interest could be on a first or second mortgage, home equity loan, or refinanced mortgage.</entry>
 </row>
-<row><entry><para><emphasis>  Sched A \ </emphasis>N274</para><para>Medical travel and lodging</para></entry>
-<entry>Lodging expenses while away from home to receive medical care in a hospital or a medical care facility related to a hospital. Do not include more than $50 a night for each eligible person. Ambulance service and other travel costs to get medical care.</entry>
+<row><entry><para><emphasis>  Sched A \ </emphasis>N284</para><para>Points paid (no 1098)</para></entry>
+<entry>Generally, you must deduct points you paid to refinance a mortgage over the life of the loan. If you used part of the proceeds to improve your main home, you may be able to deduct the part of the points related to the improvement in the year paid. See Pub. 936 Use this line for points not reported on Form 1098.</entry>
 </row>
-<row><entry><para><emphasis>  Sched A \ </emphasis>N273</para><para>Medicine and drugs</para></entry>
-<entry>Prescription medicines, eyeglasses, contact lenses, hearing aids. Over-the-counter medicines are not deductible.</entry>
-</row>
-<row><entry><para><emphasis>  Sched A \ </emphasis>N523</para><para>Misc., no 2% AGI limit</para></entry>
-<entry>Other miscellaneous itemized deductions that are not reduced by 2% of adjusted gross income, such as casualty and theft losses from income-producing, amortizable bond premium on bonds acquired before October 23, 1986, federal estate tax on income in respect to a decedent, certain unrecovered investment in a pension, impairment-related work expenses of a disabled person.</entry>
+<row><entry><para><emphasis>  Sched A \ </emphasis>N484</para><para>Doctors, dentists, hospitals</para></entry>
+<entry>Insurance premiums for medical and dental care, medical doctors, dentists, eye doctors, surgeons, X-ray, laboratory services, hospital care, etc. See IRS Pub 502.</entry>
 </row>
 <row><entry><para><emphasis>  Sched A \ </emphasis>N486</para><para>Misc., subject to 2% AGI limit</para></entry>
 <entry>Safety equipment, small tools, and supplies you needed for your job; Uniforms required by your employer and which you may not usually wear away from work; subscriptions to professional journals; job search expenses; certain educational expenses. You may need to file Form 2106.</entry>
@@ -540,35 +545,24 @@
 <entry>
 The fair market value of donated property, such as used clothing or furniture.</entry>
 </row>
-<row><entry><para><emphasis>  Sched A \ </emphasis>N277</para><para>Other taxes</para></entry>
-<entry>Other taxes paid not included under state and local income taxes, real estate taxes, or personal property taxes. You may want to take a credit for the foreign tax instead of a deduction.</entry>
+<row><entry><para><emphasis>  Sched A \ </emphasis>N522</para><para>State estimated tax, quarterly</para></entry>
+<entry>State estimated tax payments made this year.</entry>
+</row>
+<row><entry><para><emphasis>  Sched A \ </emphasis>N523</para><para>Misc., no 2% AGI limit</para></entry>
+<entry>Other miscellaneous itemized deductions that are not reduced by 2% of adjusted gross income, such as casualty and theft losses from income-producing, amortizable bond premium on bonds acquired before October 23, 1986, federal estate tax on income in respect to a decedent, certain unrecovered investment in a pension, impairment-related work expenses of a disabled person.</entry>
 </row>
 <row><entry><para><emphasis>  Sched A \ </emphasis>N535</para><para>Personal property taxes</para></entry>
 <entry>Enter personal property tax you paid, but only if it is based on value alone. Example: You paid a fee for the registration of your car. Part of the fee was based on the car s value and part was based on its weight. You may deduct only the part of the fee that is based on the car s value.</entry>
 </row>
-<row><entry><para><emphasis>  Sched A \ </emphasis>N284</para><para>Points paid (no 1098)</para></entry>
-<entry>Generally, you must deduct points you paid to refinance a mortgage over the life of the loan. If you used part of the proceeds to improve your main home, you may be able to deduct the part of the points related to the improvement in the year paid. See Pub. 936 Use this line for points not reported on Form 1098.</entry>
+<row><entry><para><emphasis>  Sched A \ </emphasis>N544</para><para>Local income taxes</para></entry>
+<entry>Local income taxes that were not withheld from your salary, such as local income taxes you paid this year for a prior year.
+</entry>
 </row>
-<row><entry><para><emphasis>  Sched A \ </emphasis>N276</para><para>Real estate taxes</para></entry>
-<entry>Include taxes (state, local, or foreign) you paid on real estate you own that was not used for business, but only if the taxes are based on the assessed value of the property. Do not include taxes charged for improvements that tend to increase the value of your property (for example, an assessment to build a new sidewalk).</entry>
-</row>
-<row><entry><para><emphasis>  Sched A \ </emphasis>N522</para><para>State estimated tax, quarterly</para></entry>
-<entry>State estimated tax payments made this year.</entry>
-</row>
-<row><entry><para><emphasis>  Sched A \ </emphasis>N275</para><para>State income taxes</para></entry>
-<entry>State income taxes paid this year for a prior year. Include any part of a prior year refund that you chose to have credited to this years state income taxes.</entry>
-</row>
-<row><entry><para><emphasis>  Sched A \ </emphasis>N271</para><para>Subscriptions</para></entry>
-<entry>Amounts paid for subscriptions to magazines or services that are directly related to the production or collection of taxable income.  (example: subscriptions to investment publications, stock newsletters, etc.).</entry>
-</row>
-<row><entry><para><emphasis>  Sched A \ </emphasis>N281</para><para>Tax preparation fees</para></entry>
-<entry>Fees you paid for preparation of your tax return, including fees paid for filing your return electronically.</entry>
+<row><entry><para><emphasis>  Sched A \ </emphasis>N545</para><para>Home mortgage interest (no 1098)</para></entry>
+<entry>Home mortgage interest paid, for which you did not receive a Form 1098 from the recipient. The interest could be on a first or second mortgage, home equity loan, or refinanced mortgage.</entry>
 </row>
 <row><entry><para><emphasis>Help Sched B \ </emphasis>H285</para><para>Schedule B - interest and dividend income</para></entry>
 <entry>Schedule B is used to report your interest and dividend income.</entry>
-</row>
-<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N487</para><para>Dividend income, non-taxable</para></entry>
-<entry>Some mutual funds pay shareholders non-taxable dividends. The amount of non-taxable dividends are indicated on your monthly statements or Form 1099-DIV.</entry>
 </row>
 <row><entry><para><emphasis>^ Sched B \ </emphasis>N286</para><para>Dividend income, Ordinary</para></entry>
 <entry>Ordinary dividends from mutual funds, stocks, etc., are reported to you on a 1099-DIV.  Note: these are sometimes called short term capital gain distributions. Do not include (long term) capital gain distributions or non-taxable dividends here, these go on Sched D</entry>
@@ -576,17 +570,20 @@ The fair market value of donated property, such as used clothing or furniture.</
 <row><entry><para><emphasis>&lt; Sched B \ </emphasis>N287</para><para>Interest income</para></entry>
 <entry>Taxable interest includes interest you receive from bank accounts, credit unions, loans you made to others. There are several categories of interest, be sure you select the correct one!</entry>
 </row>
-<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N489</para><para>Interest income, non-taxable</para></entry>
-<entry>Non-taxable interest income other than from bonds or notes of states, counties, cities, the District of Columbia, or a possession of the United States, or from a qualified private activity bond. There are several categories of interest, be sure you select the correct one!</entry>
-</row>
-<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N492</para><para>Interest income, OID bonds</para></entry>
-<entry>Interest income from Original Issue Discount (OID) bonds will be reported to you on Form 1099-OID. There are several categories of interest, be sure you select the correct one!</entry>
-</row>
-<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N524</para><para>Interest income, Seller-financed mortgage</para></entry>
-<entry>Interest the buyer paid you on a mortgage or other form of seller financing, for your home or other property and the buyer used the property as a personal residence. There are several categories of interest, be sure you select the correct one!</entry>
+<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N288</para><para>Interest income, US government</para></entry>
+<entry>Interest on U.S. obligations, such as U.S. Treasury bills, notes, and bonds issued by any agency of the United States. This income is exempt from all state and local income taxes. There are several categories of interest, be sure you select the correct one!</entry>
 </row>
 <row><entry><para><emphasis>&lt; Sched B \ </emphasis>N289</para><para>Interest income, State and municipal bond</para></entry>
 <entry>Interest on bonds or notes of states, counties, cities, the District of Columbia, or possessions of the United States is generally free of federal income tax (but you may pay state income tax). There are several categories of interest, be sure you select the correct one!</entry>
+</row>
+<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N290</para><para>Interest income, tax-exempt private activity bond</para></entry>
+<entry>Interest income from a qualified tax-exempt private activity bond is not taxable if it meets all requirements. This income is included on your Schedule B as non-taxable interest income. There are several categories of interest, be sure you select the correct one!</entry>
+</row>
+<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N487</para><para>Dividend income, non-taxable</para></entry>
+<entry>Some mutual funds pay shareholders non-taxable dividends. The amount of non-taxable dividends are indicated on your monthly statements or Form 1099-DIV.</entry>
+</row>
+<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N489</para><para>Interest income, non-taxable</para></entry>
+<entry>Non-taxable interest income other than from bonds or notes of states, counties, cities, the District of Columbia, or a possession of the United States, or from a qualified private activity bond. There are several categories of interest, be sure you select the correct one!</entry>
 </row>
 <row><entry><para><emphasis>&lt; Sched B \ </emphasis>N490</para><para>Interest income, taxed only by fed</para></entry>
 <entry>Interest income that is taxed on your federal return, but not on your state income tax return - other than interest paid on U.S. obligations. There are several categories of interest, be sure you select the correct one!</entry>
@@ -594,11 +591,11 @@ The fair market value of donated property, such as used clothing or furniture.</
 <row><entry><para><emphasis>&lt; Sched B \ </emphasis>N491</para><para>Interest income, taxed only by state</para></entry>
 <entry>Interest income that is not taxed on your federal return, but is taxed on your state income tax return - other than interest income from state bonds or notes, the District of Columbia, or a possession of the United States. There are several categories of interest, be sure you select the correct one!</entry>
 </row>
-<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N290</para><para>Interest income, tax-exempt private activity bond</para></entry>
-<entry>Interest income from a qualified tax-exempt private activity bond is not taxable if it meets all requirements. This income is included on your Schedule B as non-taxable interest income. There are several categories of interest, be sure you select the correct one!</entry>
+<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N492</para><para>Interest income, OID bonds</para></entry>
+<entry>Interest income from Original Issue Discount (OID) bonds will be reported to you on Form 1099-OID. There are several categories of interest, be sure you select the correct one!</entry>
 </row>
-<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N288</para><para>Interest income, US government</para></entry>
-<entry>Interest on U.S. obligations, such as U.S. Treasury bills, notes, and bonds issued by any agency of the United States. This income is exempt from all state and local income taxes. There are several categories of interest, be sure you select the correct one!</entry>
+<row><entry><para><emphasis>&lt; Sched B \ </emphasis>N524</para><para>Interest income, Seller-financed mortgage</para></entry>
+<entry>Interest the buyer paid you on a mortgage or other form of seller financing, for your home or other property and the buyer used the property as a personal residence. There are several categories of interest, be sure you select the correct one!</entry>
 </row>
 <row><entry><para><emphasis>&lt; Sched B \ </emphasis>N615</para><para>Fed tax withheld, dividend income</para></entry>
 <entry>The amount of federal income taxes withheld from dividend income. This is usually reported on Form 1099-DIV.</entry>
@@ -611,6 +608,30 @@ The fair market value of donated property, such as used clothing or furniture.</
 </row>
 <row><entry><para><emphasis>  Sched C \ </emphasis>N293</para><para>Gross receipts or sales</para></entry>
 <entry>The amount of gross receipts from your trade or business. Include amounts you received in your trade or business that were properly shown on Forms 1099-MISC.</entry>
+</row>
+<row><entry><para><emphasis>  Sched C \ </emphasis>N294</para><para>Meals and entertainment</para></entry>
+<entry>Total business meal and entertainment expenses. Business meal expenses are deductible only if they are (a) directly related to or associated with the active conduct of your trade or business, (b) not lavish or extravagant, and (c) incurred while you or your employee is present at the meal.</entry>
+</row>
+<row><entry><para><emphasis>  Sched C \ </emphasis>N296</para><para>Returns and allowances</para></entry>
+<entry>Credits you allow customers for returned merchandise and any other allowances you make on sales.</entry>
+</row>
+<row><entry><para><emphasis>  Sched C \ </emphasis>N297</para><para>Wages paid</para></entry>
+<entry>The total amount of salaries and wages for the tax year. Do not include amounts paid to yourself.</entry>
+</row>
+<row><entry><para><emphasis>  Sched C \ </emphasis>N298</para><para>Legal and professional fees</para></entry>
+<entry>Accountant&rsquo;s or legal fees for tax advice related to your business and for preparation of the tax forms related to your business.</entry>
+</row>
+<row><entry><para><emphasis>  Sched C \ </emphasis>N299</para><para>Rent/lease vehicles, equip.</para></entry>
+<entry>The amount paid to rent or lease vehicles, machinery, or equipment, for your business. If you leased a vehicle for a term of 30 days or more, you may have to reduce your deduction by an amount called the inclusion amount. See Pub. 463.</entry>
+</row>
+<row><entry><para><emphasis>  Sched C \ </emphasis>N300</para><para>Rent/lease other business property</para></entry>
+<entry>The amounts paid to rent or lease real estate or  property, such as office space in a building.</entry>
+</row>
+<row><entry><para><emphasis>  Sched C \ </emphasis>N301</para><para>Supplies (not from Cost of Goods Sold)</para></entry>
+<entry>The cost of supplies not reported under Cost Of Goods Sold.</entry>
+</row>
+<row><entry><para><emphasis>  Sched C \ </emphasis>N302</para><para>Other business expenses</para></entry>
+<entry>Other costs not specified on other lines of Schedule C, such as: Clean-fuel vehicles and refueling property; Donations to business organizations; Educational expenses; Environmental cleanup costs; Impairment-related expenses; Interview expense allowances; Licenses and regulatory fees; Moving machinery; Outplacement services; Penalties and fines you pay for late performance or nonperformance of a contract; Subscriptions to trade or professional publications.</entry>
 </row>
 <row><entry><para><emphasis>  Sched C \ </emphasis>N303</para><para>Other business income</para></entry>
 <entry>The amounts from finance reserve income, scrap sales, bad debts you recovered, interest (such as on notes and accounts receivable), state gasoline or fuel tax refunds you got this year, prizes and awards related to your trade or business, and other kinds of miscellaneous business income.</entry>
@@ -627,23 +648,11 @@ The fair market value of donated property, such as used clothing or furniture.</
 <row><entry><para><emphasis>  Sched C \ </emphasis>N307</para><para>Commissions and fees</para></entry>
 <entry>The amounts of commissions or fees paid to independent contractors (non employees) for their services.</entry>
 </row>
-<row><entry><para><emphasis>  Sched C \ </emphasis>N494</para><para>Cost of Goods Sold - Labor</para></entry>
-<entry>Labor costs are usually an element of cost of goods sold only in a manufacturing or mining business. In a manufacturing business, labor costs that are properly allocable to the cost of goods sold include both the direct and indirect labor used in fabricating the raw material into a finished, salable product.</entry>
-</row>
-<row><entry><para><emphasis>  Sched C \ </emphasis>N495</para><para>Cost of Goods Sold - Materials/supplies</para></entry>
-<entry>Materials and supplies, such as hardware and chemicals, used in manufacturing goods are charged to cost of goods sold. Those that are not used in the manufacturing process are treated as deferred charges. You deduct them as a business expense when you use them.</entry>
-</row>
-<row><entry><para><emphasis>  Sched C \ </emphasis>N496</para><para>Cost of Goods Sold - Other costs</para></entry>
-<entry>Other costs incurred in a manufacturing or mining process that you charge to your cost of goods sold are containers, freight-in, overhead expenses.</entry>
-</row>
-<row><entry><para><emphasis>  Sched C \ </emphasis>N493</para><para>Cost of Goods Sold - Purchases</para></entry>
-<entry>If you are a merchant, use the cost of all merchandise you bought for sale. If you are a manufacturer or producer, this includes the cost of all raw materials or parts purchased for manufacture into a finished product. You must exclude the cost of merchandise you withdraw for your personal or family use.</entry>
+<row><entry><para><emphasis>  Sched C \ </emphasis>N308</para><para>Employee benefit programs</para></entry>
+<entry>Contributions to employee benefit programs that are not an incidental part of a pension or profit-sharing plan. Examples are accident and health plans, group-term life insurance, and dependent care assistance programs.</entry>
 </row>
 <row><entry><para><emphasis>  Sched C \ </emphasis>N309</para><para>Depletion</para></entry>
 <entry>The amounts for depletion. If you have timber depletion, attach Form T.  See Pub. 535.</entry>
-</row>
-<row><entry><para><emphasis>  Sched C \ </emphasis>N308</para><para>Employee benefit programs</para></entry>
-<entry>Contributions to employee benefit programs that are not an incidental part of a pension or profit-sharing plan. Examples are accident and health plans, group-term life insurance, and dependent care assistance programs.</entry>
 </row>
 <row><entry><para><emphasis>  Sched C \ </emphasis>N310</para><para>Insurance, other than health</para></entry>
 <entry>Premiums paid for business insurance. Do not include amounts paid for employee accident and health insurance. nor amounts credited to a reserve for self-insurance or premiums paid for a policy that pays for your lost earnings due to sickness or disability. See Pub. 535.</entry>
@@ -654,35 +663,14 @@ The fair market value of donated property, such as used clothing or furniture.</
 <row><entry><para><emphasis>  Sched C \ </emphasis>N312</para><para>Interest expense, other</para></entry>
 <entry>The interest you paid for which you did not receive a Form 1098 (perhaps someone else did, and you are liable too), for a mortgage or other loans for your business.</entry>
 </row>
-<row><entry><para><emphasis>  Sched C \ </emphasis>N298</para><para>Legal and professional fees</para></entry>
-<entry>Accountant&rsquo;s or legal fees for tax advice related to your business and for preparation of the tax forms related to your business.</entry>
-</row>
-<row><entry><para><emphasis>  Sched C \ </emphasis>N294</para><para>Meals and entertainment</para></entry>
-<entry>Total business meal and entertainment expenses. Business meal expenses are deductible only if they are (a) directly related to or associated with the active conduct of your trade or business, (b) not lavish or extravagant, and (c) incurred while you or your employee is present at the meal.</entry>
-</row>
 <row><entry><para><emphasis>  Sched C \ </emphasis>N313</para><para>Office expenses</para></entry>
 <entry>The cost of consumable office supplies such as business cards, computer supplies, pencils, pens, postage stamps, rental of postal box or postage machines, stationery, Federal Express and UPS charges, etc.</entry>
-</row>
-<row><entry><para><emphasis>  Sched C \ </emphasis>N302</para><para>Other business expenses</para></entry>
-<entry>Other costs not specified on other lines of Schedule C, such as: Clean-fuel vehicles and refueling property; Donations to business organizations; Educational expenses; Environmental cleanup costs; Impairment-related expenses; Interview expense allowances; Licenses and regulatory fees; Moving machinery; Outplacement services; Penalties and fines you pay for late performance or nonperformance of a contract; Subscriptions to trade or professional publications.</entry>
 </row>
 <row><entry><para><emphasis>  Sched C \ </emphasis>N314</para><para>Pension/profit sharing plans</para></entry>
 <entry>You can set up and maintain the following small business retirement plans for yourself and your employees, such as: SEP (Simplified Employee Pension) plans; SIMPLE (Savings Incentive Match Plan for Employees) plans; Qualified plans (including Keogh or H.R. 10 plans). You deduct contributions you make to the plan for yourself on Form 1040.</entry>
 </row>
-<row><entry><para><emphasis>  Sched C \ </emphasis>N300</para><para>Rent/lease other business property</para></entry>
-<entry>The amounts paid to rent or lease real estate or  property, such as office space in a building.</entry>
-</row>
-<row><entry><para><emphasis>  Sched C \ </emphasis>N299</para><para>Rent/lease vehicles, equip.</para></entry>
-<entry>The amount paid to rent or lease vehicles, machinery, or equipment, for your business. If you leased a vehicle for a term of 30 days or more, you may have to reduce your deduction by an amount called the inclusion amount. See Pub. 463.</entry>
-</row>
 <row><entry><para><emphasis>  Sched C \ </emphasis>N315</para><para>Repairs and maintenance</para></entry>
 <entry>The cost of repairs and maintenance. Include labor, supplies, and other items that do not add to the value or increase the life of the property. Do not include the value of your own labor. Do not include amounts spent to restore or replace property; they must be capitalized.</entry>
-</row>
-<row><entry><para><emphasis>  Sched C \ </emphasis>N296</para><para>Returns and allowances</para></entry>
-<entry>Credits you allow customers for returned merchandise and any other allowances you make on sales.</entry>
-</row>
-<row><entry><para><emphasis>  Sched C \ </emphasis>N301</para><para>Supplies (not from Cost of Goods Sold)</para></entry>
-<entry>The cost of supplies not reported under Cost Of Goods Sold.</entry>
 </row>
 <row><entry><para><emphasis>  Sched C \ </emphasis>N316</para><para>Taxes and licenses</para></entry>
 <entry>Include the following taxes: State and local sales taxes imposed on you as the seller of goods or services; Real estate and personal property taxes on business assets; Social security and Medicare taxes paid to match required withholding from your employees&rsquo; wages; Also, Federal unemployment tax paid; Federal highway use tax.</entry>
@@ -693,20 +681,29 @@ The fair market value of donated property, such as used clothing or furniture.</
 <row><entry><para><emphasis>  Sched C \ </emphasis>N318</para><para>Utilities</para></entry>
 <entry>The costs of electricity, gas, telephone, etc. for your business property.</entry>
 </row>
-<row><entry><para><emphasis>  Sched C \ </emphasis>N297</para><para>Wages paid</para></entry>
-<entry>The total amount of salaries and wages for the tax year. Do not include amounts paid to yourself.</entry>
+<row><entry><para><emphasis>  Sched C \ </emphasis>N493</para><para>Cost of Goods Sold - Purchases</para></entry>
+<entry>If you are a merchant, use the cost of all merchandise you bought for sale. If you are a manufacturer or producer, this includes the cost of all raw materials or parts purchased for manufacture into a finished product. You must exclude the cost of merchandise you withdraw for your personal or family use.</entry>
+</row>
+<row><entry><para><emphasis>  Sched C \ </emphasis>N494</para><para>Cost of Goods Sold - Labor</para></entry>
+<entry>Labor costs are usually an element of cost of goods sold only in a manufacturing or mining business. In a manufacturing business, labor costs that are properly allocable to the cost of goods sold include both the direct and indirect labor used in fabricating the raw material into a finished, salable product.</entry>
+</row>
+<row><entry><para><emphasis>  Sched C \ </emphasis>N495</para><para>Cost of Goods Sold - Materials/supplies</para></entry>
+<entry>Materials and supplies, such as hardware and chemicals, used in manufacturing goods are charged to cost of goods sold. Those that are not used in the manufacturing process are treated as deferred charges. You deduct them as a business expense when you use them.</entry>
+</row>
+<row><entry><para><emphasis>  Sched C \ </emphasis>N496</para><para>Cost of Goods Sold - Other costs</para></entry>
+<entry>Other costs incurred in a manufacturing or mining process that you charge to your cost of goods sold are containers, freight-in, overhead expenses.</entry>
 </row>
 <row><entry><para><emphasis>Help Sched D \ </emphasis>H320</para><para>Schedule D - capital gains and losses </para></entry>
 <entry>Schedule D is used to report gains and losses from the sale of capital assets.</entry>
 </row>
-<row><entry><para><emphasis>^ Sched D \ </emphasis>N488</para><para>Dividend income, capital gain distributions</para></entry>
-<entry>Sometimes called long term capital gain distributions. These are from mutual funds, other regulated investment companies, or real estate investment trusts.  These are reported on your monthly statements or Form 1099-DIV. Note: short term capital gain distributions are reported on Sched B as ordinary dividends</entry>
+<row><entry><para><emphasis># Sched D \ </emphasis>N321</para><para>Short Term gain/loss - security</para></entry>
+<entry>Short term gain or loss from the sale of a security. Not yet implemented in <application>&app;</application>.</entry>
 </row>
 <row><entry><para><emphasis># Sched D \ </emphasis>N323</para><para>Long Term gain/loss - security</para></entry>
 <entry>Long term gain or loss from the sale of a security. Not yet implemented in <application>&app;</application>.</entry>
 </row>
-<row><entry><para><emphasis># Sched D \ </emphasis>N321</para><para>Short Term gain/loss - security</para></entry>
-<entry>Short term gain or loss from the sale of a security. Not yet implemented in <application>&app;</application>.</entry>
+<row><entry><para><emphasis>^ Sched D \ </emphasis>N488</para><para>Dividend income, capital gain distributions</para></entry>
+<entry>Sometimes called long term capital gain distributions. These are from mutual funds, other regulated investment companies, or real estate investment trusts.  These are reported on your monthly statements or Form 1099-DIV. Note: short term capital gain distributions are reported on Sched B as ordinary dividends</entry>
 </row>
 <row><entry><para><emphasis># Sched D \ </emphasis>N673</para><para>Short/Long Term gain or loss</para></entry>
 <entry>Short term or long term gain or loss from the sale of a security; for use when only the date sold and net sales amount are available and the date acquired and cost basis information is not available and will be separately added in the tax software.</entry>
@@ -738,14 +735,8 @@ The fair market value of donated property, such as used clothing or furniture.</
 <row><entry><para><emphasis>  Sched E \ </emphasis>N333</para><para>Legal and professional fees</para></entry>
 <entry>The amounts of fees for tax advice and the preparation of tax forms related to your rental real estate or royalty properties.</entry>
 </row>
-<row><entry><para><emphasis>  Sched E \ </emphasis>N502</para><para>Management fees</para></entry>
-<entry>The amount of fees to a manager or property management company to oversee your rental or royalty property.</entry>
-</row>
 <row><entry><para><emphasis>  Sched E \ </emphasis>N334</para><para>Mortgage interest expense</para></entry>
 <entry>Interest paid to banks or other financial institutions for a mortgage on your rental property, and you received a Form 1098.</entry>
-</row>
-<row><entry><para><emphasis>  Sched E \ </emphasis>N341</para><para>Other expenses</para></entry>
-<entry>Other expenses that are not listed on other tax lines of Schedule E.  These might include the cost of gardening and/or snow removal services, association dues, bank charges, etc.</entry>
 </row>
 <row><entry><para><emphasis>  Sched E \ </emphasis>N335</para><para>Other interest expense</para></entry>
 <entry>Interest paid for a mortgage on your rental property, not paid to banks or other financial institutions or you did not receive a Form 1098.</entry>
@@ -762,71 +753,20 @@ The fair market value of donated property, such as used clothing or furniture.</
 <row><entry><para><emphasis>  Sched E \ </emphasis>N339</para><para>Utilities</para></entry>
 <entry>The costs of electricity, gas, telephone, etc. for your rental property.</entry>
 </row>
+<row><entry><para><emphasis>  Sched E \ </emphasis>N341</para><para>Other expenses</para></entry>
+<entry>Other expenses that are not listed on other tax lines of Schedule E.  These might include the cost of gardening and/or snow removal services, association dues, bank charges, etc.</entry>
+</row>
+<row><entry><para><emphasis>  Sched E \ </emphasis>N502</para><para>Management fees</para></entry>
+<entry>The amount of fees to a manager or property management company to oversee your rental or royalty property.</entry>
+</row>
 <row><entry><para><emphasis>Help Sched F \ </emphasis>H343</para><para>Schedule F - Farm income and expense</para></entry>
 <entry>Schedule F is used to report farm income and expense. Use a different copy of Schedule F for each farm you own.</entry>
 </row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N372</para><para>Agricultural program payments</para></entry>
-<entry>Government payments received for: price support payments, market gain from the repayment of a secured Commodity Credit Corporation (CCC) loan for less than the original loan amount, diversion payments, cost-share payments (sight drafts), payments in the form of materials (such as fertilizer or lime) or services (such as grading or building dams). Reported on Form 1099-G.</entry>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N344</para><para>Labor hired</para></entry>
+<entry>The amounts you paid for farm labor. Do not include amounts paid to yourself.  Count the cost of boarding farm labor but not the value of any products they used from the farm. Count only what you paid house-hold help to care for farm laborers.</entry>
 </row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N374</para><para>CCC loans forfeited or repaid</para></entry>
-<entry>The amount forfeited or repaid with certificates, even if you reported the loan proceeds as income.  See IRS Pub 225.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N373</para><para>CCC loans reported/election</para></entry>
-<entry>Generally, you do not report CCC loan proceeds as income. However, if you pledge part or all of your production to secure a CCC loan, you may elect to report the loan proceeds as income in the year you receive them, instead of the year you sell the crop.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N376</para><para>Crop insurance proceeds deferred</para></entry>
-<entry>If you use the cash method of accounting and receive crop insurance proceeds in the same tax year in which the crops are damaged, you can choose to postpone reporting the proceeds as income until the following tax year. A statement must also be attached to your return.  See IRS Pub 225.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N375</para><para>Crop insurance proceeds received</para></entry>
-<entry>You generally include crop insurance proceeds in the year you receive them. Treat as crop insurance proceeds the crop disaster payments you receive from the federal government.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N370</para><para>Custom hire income</para></entry>
-<entry>The income you received for custom hire (machine work).</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N377</para><para>Other farm income</para></entry>
-<entry>Illegal Federal irrigation subsidies, bartering income, income from discharge of indebtedness, state gasoline or fuel tax refund, the gain or loss on the sale of commodity futures contracts, etc.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N369</para><para>Resales of livestock/items</para></entry>
-<entry>Amounts you received from the sales of livestock and other items you bought specifically for resale. Do not include sales of livestock held for breeding, dairy purposes, draft, or sport.  These are reported on Form 4797, Sales of Business Property.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N368</para><para>Sales livestock/product raised</para></entry>
-<entry>Amounts you received from the sale of livestock, produce, grains, and other products you raised.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N371</para><para>Total cooperative distributions</para></entry>
-<entry>Distributions received from a cooperative. This includes patronage dividends, non patronage distributions, per-unit retain allocations, and redemption of non qualified notices and per unit retain allocations. Reported on Form 1099-PATR.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N543</para><para>Car and truck expenses</para></entry>
-<entry>The business portion of car or truck expenses, such as, for gasoline, oil, repairs, insurance, tires, license plates, etc.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N366</para><para>Chemicals</para></entry>
-<entry>Chemicals used in operating your farm, such as insect sprays and dusts.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N362</para><para>Conservation expenses</para></entry>
-<entry>Your expenses for soil or water conservation or for the prevention of erosion of land used in farming. To take this deduction, your expenses must be consistent with a plan approved by the Natural Resources Conservation Service (NRCS) of the Department of Agriculture.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N378</para><para>Cost of resale livestock/items</para></entry>
-<entry>The cost or other basis of the livestock and other items you actually sold.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N367</para><para>Custom hire expenses</para></entry>
-<entry>Amounts you paid for custom hire (machine work) (the machine operator furnished the equipment).  Do not include amounts paid for rental or lease of equipment you operated yourself.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N364</para><para>Employee benefit programs</para></entry>
-<entry>Contributions to employee benefit programs, such as accident and health plans, group-term life insurance, and dependent care assistance programs. Do not include contributions  that are a incidental part of a pension or profit-sharing plan.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N350</para><para>Feed purchased</para></entry>
-<entry>The cost of feed for your livestock. Generally, you cannot currently deduct expenses for feed to be consumed by your livestock in a later tax year. See instructions for Schedule F.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N352</para><para>Fertilizers and lime</para></entry>
-<entry>The cost of fertilizer, lime, and other materials applied to farm land to enrich, neutralize, or condition it. You can also deduct the cost of applying these materials. However, see Prepaid Farm Supplies, in Pub 225, for a rule that may limit your deduction for these materials.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N361</para><para>Freight and trucking</para></entry>
-<entry>The costs of freight or trucking of produce or livestock.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N356</para><para>Gasoline, fuel, and oil</para></entry>
-<entry>The costs of gas, fuel, oil, etc. for farm equipment.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N359</para><para>Insurance, other than health</para></entry>
-<entry>Premiums paid for farm business insurance, such as: fire, storm, crop, theft and liability protection of farm assets.  Do not include premiums for employee accident and health insurance.</entry>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N345</para><para>Repairs and maintenance</para></entry>
+<entry>Amounts you paid for repairs and maintenance of farm buildings, machinery, and equipment. You can also include what you paid for tools of short life or minimal cost, such as shovels and rakes.</entry>
 </row>
 <row><entry><para><emphasis>  Sched F \ </emphasis>N346</para><para>Interest expense, mortgage</para></entry>
 <entry>The interest you paid to banks or other financial institutions for which you received a Form 1098, for a mortgage on real property used in your farming business (other than your main home). If you paid interest on a debt secured by your main home, and any proceeds from that debt were used in your farming operation, refer to IRS Pub 225.</entry>
@@ -834,41 +774,98 @@ The fair market value of donated property, such as used clothing or furniture.</
 <row><entry><para><emphasis>  Sched F \ </emphasis>N347</para><para>Interest expense, other</para></entry>
 <entry>The interest you paid for which you did not receive a Form 1098 (perhaps someone else did, and you are liable too), for a mortgage or other loans for your farm business.</entry>
 </row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N344</para><para>Labor hired</para></entry>
-<entry>The amounts you paid for farm labor. Do not include amounts paid to yourself.  Count the cost of boarding farm labor but not the value of any products they used from the farm. Count only what you paid house-hold help to care for farm laborers.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N365</para><para>Other farm expenses</para></entry>
-<entry>Include all ordinary and necessary farm expenses not deducted elsewhere on Schedule F, such as advertising, office supplies, etc. Do not include fines or penalties paid to a government for violating any law.</entry>
-</row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N363</para><para>Pension/profit sharing plans</para></entry>
-<entry>Enter your deduction for contributions to employee pension, profit-sharing, or annuity plans. If the plan included you as a self-employed person, see the instructions for Schedule C (Form 1040).</entry>
-</row>
 <row><entry><para><emphasis>  Sched F \ </emphasis>N348</para><para>Rent/lease land, animals</para></entry>
 <entry>Amounts paid to rent or lease property such as pasture or farm land.</entry>
 </row>
 <row><entry><para><emphasis>  Sched F \ </emphasis>N349</para><para>Rent/lease vehicles, equip.</para></entry>
 <entry>The business portion of your rental cost, for rented or leased vehicles, machinery, or equipment. But if you leased a vehicle for a term of 30 days or more, you may have to reduce your deduction by an inclusion amount. For details, see the instructions for Schedule C (Form 1040).</entry>
 </row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N345</para><para>Repairs and maintenance</para></entry>
-<entry>Amounts you paid for repairs and maintenance of farm buildings, machinery, and equipment. You can also include what you paid for tools of short life or minimal cost, such as shovels and rakes.</entry>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N350</para><para>Feed purchased</para></entry>
+<entry>The cost of feed for your livestock. Generally, you cannot currently deduct expenses for feed to be consumed by your livestock in a later tax year. See instructions for Schedule F.</entry>
 </row>
 <row><entry><para><emphasis>  Sched F \ </emphasis>N351</para><para>Seeds and plants purchased</para></entry>
 <entry>The amounts paid for seeds and plants purchased for farming.</entry>
 </row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N357</para><para>Storage and warehousing</para></entry>
-<entry>Amounts paid for storage and warehousing of crops, grains, etc.</entry>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N352</para><para>Fertilizers and lime</para></entry>
+<entry>The cost of fertilizer, lime, and other materials applied to farm land to enrich, neutralize, or condition it. You can also deduct the cost of applying these materials. However, see Prepaid Farm Supplies, in Pub 225, for a rule that may limit your deduction for these materials.</entry>
 </row>
 <row><entry><para><emphasis>  Sched F \ </emphasis>N353</para><para>Supplies purchased</para></entry>
 <entry>Livestock supplies and other supplies, including bedding, office supplies, etc.</entry>
 </row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N355</para><para>Vet, breeding, and medicine</para></entry>
+<entry>The costs of veterinary services, medicine and breeding fees.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N356</para><para>Gasoline, fuel, and oil</para></entry>
+<entry>The costs of gas, fuel, oil, etc. for farm equipment.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N357</para><para>Storage and warehousing</para></entry>
+<entry>Amounts paid for storage and warehousing of crops, grains, etc.</entry>
+</row>
 <row><entry><para><emphasis>  Sched F \ </emphasis>N358</para><para>Taxes</para></entry>
 <entry>Real estate and personal property taxes on farm business assets; Social security and Medicare taxes you paid to match what you are required to withhold from farm employees&rsquo; wages and any Federal unemployment tax paid; Federal highway use tax.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N359</para><para>Insurance, other than health</para></entry>
+<entry>Premiums paid for farm business insurance, such as: fire, storm, crop, theft and liability protection of farm assets.  Do not include premiums for employee accident and health insurance.</entry>
 </row>
 <row><entry><para><emphasis>  Sched F \ </emphasis>N360</para><para>Utilities</para></entry>
 <entry>Amounts you paid for gas, electricity, water, etc., for business use on the farm. Do not include personal utilities. You cannot deduct the base rate (including taxes) of the first telephone line into your residence, even if you use it for business.</entry>
 </row>
-<row><entry><para><emphasis>  Sched F \ </emphasis>N355</para><para>Vet, breeding, and medicine</para></entry>
-<entry>The costs of veterinary services, medicine and breeding fees.</entry>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N361</para><para>Freight and trucking</para></entry>
+<entry>The costs of freight or trucking of produce or livestock.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N362</para><para>Conservation expenses</para></entry>
+<entry>Your expenses for soil or water conservation or for the prevention of erosion of land used in farming. To take this deduction, your expenses must be consistent with a plan approved by the Natural Resources Conservation Service (NRCS) of the Department of Agriculture.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N363</para><para>Pension/profit sharing plans</para></entry>
+<entry>Enter your deduction for contributions to employee pension, profit-sharing, or annuity plans. If the plan included you as a self-employed person, see the instructions for Schedule C (Form 1040).</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N364</para><para>Employee benefit programs</para></entry>
+<entry>Contributions to employee benefit programs, such as accident and health plans, group-term life insurance, and dependent care assistance programs. Do not include contributions  that are a incidental part of a pension or profit-sharing plan.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N365</para><para>Other farm expenses</para></entry>
+<entry>Include all ordinary and necessary farm expenses not deducted elsewhere on Schedule F, such as advertising, office supplies, etc. Do not include fines or penalties paid to a government for violating any law.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N366</para><para>Chemicals</para></entry>
+<entry>Chemicals used in operating your farm, such as insect sprays and dusts.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N367</para><para>Custom hire expenses</para></entry>
+<entry>Amounts you paid for custom hire (machine work) (the machine operator furnished the equipment).  Do not include amounts paid for rental or lease of equipment you operated yourself.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N372</para><para>Agricultural program payments</para></entry>
+<entry>Government payments received for: price support payments, market gain from the repayment of a secured Commodity Credit Corporation (CCC) loan for less than the original loan amount, diversion payments, cost-share payments (sight drafts), payments in the form of materials (such as fertilizer or lime) or services (such as grading or building dams). Reported on Form 1099-G.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N373</para><para>CCC loans reported/election</para></entry>
+<entry>Generally, you do not report CCC loan proceeds as income. However, if you pledge part or all of your production to secure a CCC loan, you may elect to report the loan proceeds as income in the year you receive them, instead of the year you sell the crop.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N374</para><para>CCC loans forfeited or repaid</para></entry>
+<entry>The amount forfeited or repaid with certificates, even if you reported the loan proceeds as income.  See IRS Pub 225.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N375</para><para>Crop insurance proceeds received</para></entry>
+<entry>You generally include crop insurance proceeds in the year you receive them. Treat as crop insurance proceeds the crop disaster payments you receive from the federal government.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N376</para><para>Crop insurance proceeds deferred</para></entry>
+<entry>If you use the cash method of accounting and receive crop insurance proceeds in the same tax year in which the crops are damaged, you can choose to postpone reporting the proceeds as income until the following tax year. A statement must also be attached to your return.  See IRS Pub 225.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N377</para><para>Other farm income</para></entry>
+<entry>Illegal Federal irrigation subsidies, bartering income, income from discharge of indebtedness, state gasoline or fuel tax refund, the gain or loss on the sale of commodity futures contracts, etc.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N368</para><para>Sales livestock/product raised</para></entry>
+<entry>Amounts you received from the sale of livestock, produce, grains, and other products you raised.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N369</para><para>Resales of livestock/items</para></entry>
+<entry>Amounts you received from the sales of livestock and other items you bought specifically for resale. Do not include sales of livestock held for breeding, dairy purposes, draft, or sport.  These are reported on Form 4797, Sales of Business Property.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N370</para><para>Custom hire income</para></entry>
+<entry>The income you received for custom hire (machine work).</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N371</para><para>Total cooperative distributions</para></entry>
+<entry>Distributions received from a cooperative. This includes patronage dividends, non patronage distributions, per-unit retain allocations, and redemption of non qualified notices and per unit retain allocations. Reported on Form 1099-PATR.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N378</para><para>Cost of resale livestock/items</para></entry>
+<entry>The cost or other basis of the livestock and other items you actually sold.</entry>
+</row>
+<row><entry><para><emphasis>  Sched F \ </emphasis>N543</para><para>Car and truck expenses</para></entry>
+<entry>The business portion of car or truck expenses, such as, for gasoline, oil, repairs, insurance, tires, license plates, etc.</entry>
 </row>
 <row><entry><para><emphasis>Help Sched H \ </emphasis>H565</para><para>Schedule H - Household employees</para></entry>
 <entry>Schedule H is used to report Federal employment taxes on cash wages paid this year to household employees.  Federal employment taxes include social security, Medicare, withheld Federal income, and Federal unemployment (FUTA) taxes.</entry>
@@ -882,32 +879,32 @@ The fair market value of donated property, such as used clothing or furniture.</
 <row><entry><para><emphasis>Help Sched K-1 \ </emphasis>H446</para><para>Schedule K-1 - partnership income, credits, deductions</para></entry>
 <entry>Schedule K-1 is used to report your share of a partnership&rsquo;s income, credits, deductions, etc.  Use a separate copy of Schedule K-1 for each partnership.</entry>
 </row>
-<row><entry><para><emphasis>  Sched K-1 \ </emphasis>N452</para><para>Dividends, ordinary</para></entry>
-<entry>The amount of dividend income the partnership reported to you on Schedule K-1. (You report this on Schedule B)</entry>
-</row>
-<row><entry><para><emphasis>  Sched K-1 \ </emphasis>N455</para><para>Guaranteed partner payments</para></entry>
-<entry>A guaranteed payments the partnership reported to you on Schedule K-1. (You report this on Schedule E)</entry>
-</row>
-<row><entry><para><emphasis>  Sched K-1 \ </emphasis>N451</para><para>Interest income</para></entry>
-<entry>The amount of interest income the partnership reported to you on Schedule K-1. (You report this on Schedule B)</entry>
-</row>
-<row><entry><para><emphasis># Sched K-1 \ </emphasis>N454</para><para>Net LT capital gain or loss</para></entry>
-<entry>The long-term gain or (loss) from the sale of assets the partnership reported to you on Schedule K-1. (You report this on Schedule D)</entry>
-</row>
-<row><entry><para><emphasis># Sched K-1 \ </emphasis>N453</para><para>Net ST capital gain or loss</para></entry>
-<entry>The short-term gain or (loss) from sale of assets the partnership reported to you on K-1. (You report this on Schedule D)</entry>
-</row>
-<row><entry><para><emphasis># Sched K-1 \ </emphasis>N456</para><para>Net Section 1231 gain or loss</para></entry>
-<entry>The gain or (loss) from sale of Section 1231 assets the partnership reported to you on Schedule K-1. (You report this on Form 4797)</entry>
-</row>
 <row><entry><para><emphasis># Sched K-1 \ </emphasis>N448</para><para>Ordinary income or loss</para></entry>
 <entry>Your share of the ordinary income (loss) from the trade or business activities of the partnership. This is reported to you on Schedule K-1. (You usually report this on Schedule E, See instructions for Schedule K-1)</entry>
+</row>
+<row><entry><para><emphasis># Sched K-1 \ </emphasis>N449</para><para>Rental real estate income or loss</para></entry>
+<entry>The income or (loss) from rental real estate activities engaged in by the partnership. This is reported to you on Schedule K-1. (You usually report this on Schedule E, See instructions for Schedule K-1)</entry>
 </row>
 <row><entry><para><emphasis># Sched K-1 \ </emphasis>N450</para><para>Other rental income or loss</para></entry>
 <entry>The income or (loss) from rental activities, other than the rental of real estate.  This is reported to you on Schedule K-1. (You usually report this on Schedule E, See instructions for Schedule K-1)</entry>
 </row>
-<row><entry><para><emphasis># Sched K-1 \ </emphasis>N449</para><para>Rental real estate income or loss</para></entry>
-<entry>The income or (loss) from rental real estate activities engaged in by the partnership. This is reported to you on Schedule K-1. (You usually report this on Schedule E, See instructions for Schedule K-1)</entry>
+<row><entry><para><emphasis>  Sched K-1 \ </emphasis>N451</para><para>Interest income</para></entry>
+<entry>The amount of interest income the partnership reported to you on Schedule K-1. (You report this on Schedule B)</entry>
+</row>
+<row><entry><para><emphasis>  Sched K-1 \ </emphasis>N452</para><para>Dividends, ordinary</para></entry>
+<entry>The amount of dividend income the partnership reported to you on Schedule K-1. (You report this on Schedule B)</entry>
+</row>
+<row><entry><para><emphasis># Sched K-1 \ </emphasis>N453</para><para>Net ST capital gain or loss</para></entry>
+<entry>The short-term gain or (loss) from sale of assets the partnership reported to you on K-1. (You report this on Schedule D)</entry>
+</row>
+<row><entry><para><emphasis># Sched K-1 \ </emphasis>N454</para><para>Net LT capital gain or loss</para></entry>
+<entry>The long-term gain or (loss) from the sale of assets the partnership reported to you on Schedule K-1. (You report this on Schedule D)</entry>
+</row>
+<row><entry><para><emphasis>  Sched K-1 \ </emphasis>N455</para><para>Guaranteed partner payments</para></entry>
+<entry>A guaranteed payments the partnership reported to you on Schedule K-1. (You report this on Schedule E)</entry>
+</row>
+<row><entry><para><emphasis># Sched K-1 \ </emphasis>N456</para><para>Net Section 1231 gain or loss</para></entry>
+<entry>The gain or (loss) from sale of Section 1231 assets the partnership reported to you on Schedule K-1. (You report this on Form 4797)</entry>
 </row>
 <row><entry><para><emphasis>  Sched K-1 \ </emphasis>N527</para><para>Royalties</para></entry>
 <entry>The amount of the royalty income the partnership reported to you on Schedule K-1. (You report this on Schedule E)</entry>
@@ -918,53 +915,53 @@ The fair market value of donated property, such as used clothing or furniture.</
 <row><entry><para><emphasis>Help W-2 \ </emphasis>H458</para><para>Form W-2 - Wages earned and taxes withheld</para></entry>
 <entry>Form W-2 is used by your employer to report the amount of wages and other compensation you earned as an employee, and the amount of federal and state taxes withheld and fringe benefits received. Use a separate copy of Form W-2 for each employer.</entry>
 </row>
-<row><entry><para><emphasis>^ W-2 \ </emphasis>N465</para><para>Dependent care benefits, self</para></entry>
-<entry>The amount dependent care benefits, including the fair market value of employer-provided or employer-sponsored day-care facilities you received.</entry>
-</row>
-<row><entry><para><emphasis>^ W-2 \ </emphasis>N512</para><para>Dependent care benefits, spouse</para></entry>
-<entry>The amount dependent care benefits, including the fair market value of employer-provided or employer-sponsored day-care facilities your spouse received.</entry>
-</row>
 <row><entry><para><emphasis>^ W-2 \ </emphasis>N267</para><para>Reimbursed moving expenses, self</para></entry>
 <entry>Qualified moving expense reimbursements paid directly to you by an employer.</entry>
-</row>
-<row><entry><para><emphasis>^ W-2 \ </emphasis>N546</para><para>Reimbursed moving expenses, spouse</para></entry>
-<entry>Qualified moving expense reimbursements paid directly to your spouse by your spouse&rsquo;s employer.</entry>
 </row>
 <row><entry><para><emphasis>^ W-2 \ </emphasis>N460</para><para>Salary or wages, self</para></entry>
 <entry>The total wages, tips, and other compensation, before any payroll deductions, you receive from your employer.</entry>
 </row>
-<row><entry><para><emphasis>^ W-2 \ </emphasis>N506</para><para>Salary or wages, spouse</para></entry>
-<entry>The total wages, tips, and other compensation, before any payroll deductions, your spouse receives from your spouse&rsquo;s employer.</entry>
-</row>
 <row><entry><para><emphasis>^ W-2 \ </emphasis>N461</para><para>Federal tax withheld, self</para></entry>
 <entry>The amount of Federal income tax withheld from your wages for the year.</entry>
-</row>
-<row><entry><para><emphasis>^ W-2 \ </emphasis>N507</para><para>Federal tax withheld, spouse</para></entry>
-<entry>The amount of Federal income tax withheld from your spouse&rsquo;s wages for the year.</entry>
-</row>
-<row><entry><para><emphasis>^ W-2 \ </emphasis>N463</para><para>Local tax withheld, self</para></entry>
-<entry>The amount of local taxes withheld from your wages.</entry>
-</row>
-<row><entry><para><emphasis>^ W-2 \ </emphasis>N509</para><para>Local tax withheld, spouse</para></entry>
-<entry>The amount of local taxes withheld from your spouse&rsquo;s wages.</entry>
-</row>
-<row><entry><para><emphasis>^ W-2 \ </emphasis>N480</para><para>Medicare tax withheld, self</para></entry>
-<entry>The amount of Medicare taxes withheld from your wages.</entry>
-</row>
-<row><entry><para><emphasis>^ W-2 \ </emphasis>N510</para><para>Medicare tax withheld, spouse</para></entry>
-<entry>The amount of Medicare taxes withheld from your spouse&rsquo;s wages.</entry>
 </row>
 <row><entry><para><emphasis>^ W-2 \ </emphasis>N462</para><para>Social Security tax withheld, self</para></entry>
 <entry>The amount of social security taxes withheld from your wages.</entry>
 </row>
-<row><entry><para><emphasis>^ W-2 \ </emphasis>N508</para><para>Social Security tax withheld, spouse</para></entry>
-<entry>The amount of social security taxes withheld from your spouse&rsquo;s wages.</entry>
+<row><entry><para><emphasis>^ W-2 \ </emphasis>N463</para><para>Local tax withheld, self</para></entry>
+<entry>The amount of local taxes withheld from your wages.</entry>
 </row>
 <row><entry><para><emphasis>^ W-2 \ </emphasis>N464</para><para>State tax withheld, self</para></entry>
 <entry>The amount of state taxes withheld from your wages.</entry>
 </row>
+<row><entry><para><emphasis>^ W-2 \ </emphasis>N465</para><para>Dependent care benefits, self</para></entry>
+<entry>The amount dependent care benefits, including the fair market value of employer-provided or employer-sponsored day-care facilities you received.</entry>
+</row>
+<row><entry><para><emphasis>^ W-2 \ </emphasis>N480</para><para>Medicare tax withheld, self</para></entry>
+<entry>The amount of Medicare taxes withheld from your wages.</entry>
+</row>
+<row><entry><para><emphasis>^ W-2 \ </emphasis>N506</para><para>Salary or wages, spouse</para></entry>
+<entry>The total wages, tips, and other compensation, before any payroll deductions, your spouse receives from your spouse&rsquo;s employer.</entry>
+</row>
+<row><entry><para><emphasis>^ W-2 \ </emphasis>N507</para><para>Federal tax withheld, spouse</para></entry>
+<entry>The amount of Federal income tax withheld from your spouse&rsquo;s wages for the year.</entry>
+</row>
+<row><entry><para><emphasis>^ W-2 \ </emphasis>N508</para><para>Social Security tax withheld, spouse</para></entry>
+<entry>The amount of social security taxes withheld from your spouse&rsquo;s wages.</entry>
+</row>
+<row><entry><para><emphasis>^ W-2 \ </emphasis>N509</para><para>Local tax withheld, spouse</para></entry>
+<entry>The amount of local taxes withheld from your spouse&rsquo;s wages.</entry>
+</row>
+<row><entry><para><emphasis>^ W-2 \ </emphasis>N510</para><para>Medicare tax withheld, spouse</para></entry>
+<entry>The amount of Medicare taxes withheld from your spouse&rsquo;s wages.</entry>
+</row>
 <row><entry><para><emphasis>^ W-2 \ </emphasis>N511</para><para>State tax withheld, spouse</para></entry>
 <entry>The amount of state taxes withheld from your spouse&rsquo;s wages.</entry>
+</row>
+<row><entry><para><emphasis>^ W-2 \ </emphasis>N512</para><para>Dependent care benefits, spouse</para></entry>
+<entry>The amount dependent care benefits, including the fair market value of employer-provided or employer-sponsored day-care facilities your spouse received.</entry>
+</row>
+<row><entry><para><emphasis>^ W-2 \ </emphasis>N546</para><para>Reimbursed moving expenses, spouse</para></entry>
+<entry>Qualified moving expense reimbursements paid directly to your spouse by your spouse&rsquo;s employer.</entry>
 </row>
 <row><entry><para><emphasis>Help W-2G \ </emphasis>H547</para><para>Form W-2G - gambling winnings</para></entry>
 <entry>Form W-2G is used to report certain gambling winnings.</entry>


### PR DESCRIPTION
I noticed that the Tax Form and TXF code list was oddly jumbled.  I found it very difficult to determine all the codes which I could use and kept feeling like there was a lot of duplication.

First I made sure that all the TXF codes for any given Tax Form were together. Then I sorted them by the TXF codes.

The Help item for each Tax Form had been duplicated so that was removed. Also I found when I sorted them that one Home Sale item had been entirely duplicated but no other duplicates were found.

If this sorting is OK, then I can do the same for the other instance of this file (in the `de` directory).