### PR TITLE
change paper format to A4 for German PDF

### DIFF
--- a/guide/de/Makefile.am
+++ b/guide/de/Makefile.am
@@ -19,6 +19,7 @@ entities = \
  glossary.xml
 DISTCLEANFILES =  $(docname)-de.omf.out
 CLEANFILES =  $(DISTCLEANFILES)
+XSLTFLAGS_FO= --stringparam paper.type A4
 include $(top_srcdir)/xmldocs.make
 include $(top_srcdir)/pdf.make
 include $(top_srcdir)/epub.make


### PR DESCRIPTION
now it is possible to create the German PDf with paper format A4.

I looked in to the Japanese Makefile.am and found there this solution.

Can you add it to all relevant versions?