### PR TITLE
Bug 115461 Highlight need to select Account Type when adding new stk acct

### DIFF
--- a/guide/C/ch_invest.xml
+++ b/guide/C/ch_invest.xml
@@ -49,7 +49,7 @@
       <varlistentry>
         <term><emphasis>Capital gains</emphasis></term>
         <listitem>
-          <para>It is the difference between
+          <para>The difference between
           the purchase and selling prices of an investment. If the selling
           price is lower than the purchase price, this is called a
           <emphasis>capital loss</emphasis>. Also known as <emphasis>realized
@@ -60,7 +60,7 @@
       <varlistentry>
         <term><emphasis>Commission</emphasis></term>
         <listitem>
-          <para>It is the fee you pay to a broker
+          <para>The fee you pay to a broker
           to buy or sell securities.</para>
         </listitem>
       </varlistentry>
@@ -68,7 +68,7 @@
       <varlistentry>
         <term><emphasis>Common stock</emphasis></term>
         <listitem>
-          <para>It is a security that
+          <para>A security that
           represents a certain fractional ownership of a company. This is what
           you buy when you <quote>buy stock</quote> in a company on the open market. This
           is also sometimes known as <emphasis>capital
@@ -79,7 +79,7 @@
       <varlistentry>
         <term><emphasis>Compounding</emphasis></term>
         <listitem>
-          <para>It is the concept that the
+          <para>The concept that the
           reinvested interest can later earn interest of its own (interest on
           interest). This is often referred to as <emphasis>compound
           interest</emphasis>.</para>
@@ -108,7 +108,7 @@
       <varlistentry>
         <term><emphasis>Interest</emphasis></term>
         <listitem>
-          <para>It is what a borrower pays a lender
+          <para>What a borrower pays a lender
           for the use of their money. Normally, this is expressed in terms of
           a percentage of the principal per year. For example, a savings
           account with 1% interest (you are the lender, the bank is the
@@ -120,7 +120,7 @@
       <varlistentry>
         <term><emphasis>Liquidity</emphasis></term>
         <listitem>
-          <para>It is a measure of how easily
+          <para>A measure of how easily
           convertible an investment is to cash. Money in a savings account is
           very liquid, while money invested in a house has low liquidity
           because it takes time to sell a house.</para>
@@ -130,7 +130,7 @@
       <varlistentry>
         <term><emphasis>Principal</emphasis></term>
         <listitem>
-          <para>It is the original amount of money
+          <para>The original amount of money
           invested or borrowed.</para>
         </listitem>
       </varlistentry>
@@ -147,7 +147,7 @@
       <varlistentry>
         <term><emphasis>Return</emphasis></term>
         <listitem>
-          <para>It is the total income plus capital
+          <para>The total income plus capital
           gains or losses of an investment. See also
           <emphasis>Yield</emphasis>.</para>
         </listitem>
@@ -156,7 +156,7 @@
       <varlistentry>
         <term><emphasis>Risk</emphasis></term>
         <listitem>
-          <para>It is the probability that the return
+          <para>The probability that the return
           on investment is different from what was expected. Investments are
           often grouped on a scale from low risk (savings account, government
           bonds) to high risk (common stock, junk bonds). As a general rule of
@@ -167,7 +167,7 @@
       <varlistentry>
         <term><emphasis>Shareholder</emphasis></term>
         <listitem>
-          <para>Shareholder is a person who holds common
+          <para>A shareholder is a person who holds common
           stock in a company.</para>
         </listitem>
       </varlistentry>
@@ -175,7 +175,7 @@
       <varlistentry>
         <term><emphasis>Stock split</emphasis></term>
         <listitem>
-          <para>It occurs when a company offers
+          <para>Occurs when a company offers
           to issue some additional multiple of shares for each existing stock.
           For example, a <quote>2 for 1</quote> stock split means that if you own 100
           shares of a stock, you will receive an additional 100 at no cost to
@@ -188,7 +188,7 @@
       <varlistentry>
         <term><emphasis>Valuation</emphasis></term>
         <listitem>
-          <para>It is the process of determining
+          <para>The process of determining
           the market value or the price the investment would sell at in a
           <quote>reasonable time frame</quote>.</para>
         </listitem>
@@ -197,7 +197,7 @@
       <varlistentry>
         <term><emphasis>Yield</emphasis></term>
         <listitem>
-          <para>It is a measure of the amount of money
+          <para>A measure of the amount of money
           you earn from an investment (IE: how much income you receive from
           the investment). Typically this is reported as a percentage of the
           principal amount. Yield does not include capital gains or loses (see

--- a/guide/C/ch_invest.xml
+++ b/guide/C/ch_invest.xml
@@ -186,7 +186,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><emphasis>Valutation</emphasis></term>
+        <term><emphasis>Valuation</emphasis></term>
         <listitem>
           <para>It is the process of determining
           the market value or the price the investment would sell at in a
@@ -358,6 +358,32 @@
       track the investment itself; an income account to track dividend
       transactions; and expense accounts to track investment fees and
       commissions.</para>
+
+      <para>In a typical account structure, security accounts are sub accounts
+        of an asset account representing an account at a brokerage firm. The
+        brokerage account would be denominated in your local currency and it
+        would include sub accounts for each security that you trade there.
+      </para>
+
+      <para>Related purchases, sales, income and expense accounts should also
+        be in the same currency as the brokerage account.
+      </para>
+
+      <para>The security sub accounts would each be configured to contain units
+        of a single security selected from the master (user defined) security
+        list and they are expected to use the same currency as the brokerage
+        account.
+      </para>
+
+      <para>Security prices are kept in a separate area of <application>&app;
+        </application> (the Price Database - <menuchoice><guimenu>Tools
+        </guimenu><guimenuitem>Price Editor</guimenuitem></menuchoice>). This
+        contains prices for individual securities (not security accounts). All
+        prices for an individual security are in a single currency. If a 
+        security is traded in multiple currencies, then a separate security and
+        separate accounts should be set up of each currency.
+      </para>
+
     </sect2>
 
     <sect2 id="invest_custom2">
@@ -700,6 +726,12 @@ Income
           <para><emphasis>Create the New Security</emphasis> - To use a new
           stock, you must create the stock as a new commodity</para>
 
+          <note><para>Be sure to first select Account Type <emphasis>Stock
+            </emphasis> or <emphasis>Mutual Fund</emphasis> so that the
+            <guilabel>Select...</guilabel> button brings up the list of
+            securites rather than currencies.</para>
+          </note>
+
           <itemizedlist>
             <listitem>
               <para><emphasis>Select Security/Currency</emphasis> - Click on
@@ -711,8 +743,7 @@ Income
             </listitem>
 
             <listitem>
-              <para><emphasis>Type</emphasis> - Change the
-              <guilabel>type</guilabel> from current to the exchange where the
+              <para><emphasis>Type</emphasis> - Select the exchange where the
               security/commodity is traded (in this example NASDAQ).</para>
 
               <para>Select the <guibutton>New</guibutton> button to open the


### PR DESCRIPTION
Make it clearer in the Guide that you need to select Account Type before trying to select/add the Security. There are 2 commits, 2nd is just slight grammar improvement.
I had already done my commits with description of bug 115461 before bug 769256 was created, but I don't think it matters as this pull request is only to document how to work around the problem, not to actually fix it.