### PR TITLE
Modify adjust-dpi.sh to work with Ubuntu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.pyo
 *.schemas
 *~
+.*.marks
 .deps
 .libs
 .scm-links
@@ -45,6 +46,7 @@ intltool-update.in
 libtool
 ltmain.sh
 make-gnucash-potfiles
+manifest.mf
 missing
 mkinstalldirs
 stamp-h1
@@ -58,3 +60,4 @@ omf_timestamp
 /.autotools
 /.cproject
 /.project
+/nbproject

--- a/util/adjust-dpi.sh
+++ b/util/adjust-dpi.sh
@@ -2,56 +2,40 @@
 # make a list file of all the png figures
 ls *.png > list
 
-for figure in `cat list`;
+for figure in $(cat list);
 do
-# read width in pixel for the figure
-width=$(identify -format "%w" "$figure")
-# if the width is less than 90x14cm/2,54
-if [ "$width" -lt 496 ]; then
-  dpi=90
+  # get width in pixels of the figure
+  width=$(identify -format "%w" "$figure")
+  if [ "$width" -lt 496 ]; then
+    # width is less than 90x14cm/2,54
+    dpi=90
+  else
+    if [ "$width" -gt 793 ]; then
+      # width is more than 144x14cm/2,54
+      # set the new dpi to function of the image size
+      # use awk to round to 0 decimals (note awk, bc + identify ignore
+      #  locale decimal separator and use ".")
+      dpi=$(echo "scale=8; $width*2.54/14" | bc | awk '{ printf("%.0f",$1); }' )
+    else
+      # width between 496px and 793px
+      dpi=144
+    fi
+  fi
   # convert dpi from pixelsperinch to pixelspercentimeter
-  dpi_cm=$(echo "scale=2; $dpi/2.54" | bc)
-  # read the existing dpi from figure as XX PixelsPerCentimeter
+  #  Note: bc truncates to scale decimals so use awk to round to 2 decimals
+  dpi_cm=$(echo "scale=8; $dpi/2.54" | bc | awk '{ printf("%.2f",$1); }')
+  # get the existing dpi from figure as XX PixelsPerCentimeter
   existing_dpi=$(identify -format "%x" "$figure")
-  # set the future dpi of figure as XX PixelsPerCentimeter
-  future_dpi="$dpi_cm PixelsPerCentimeter"
+  # some vers of identify suffix the returned dpi with " PixelsPerCentimeter"
+  #  and/or do not round the return value of identify -format "%x"
+  existing_dpi=$( echo "$existing_dpi" | awk '{ printf("%.2f",$1); }')
+  # set the future dpi figure to XX.XX (PixelsPerCentimeter)
+  future_dpi="$dpi_cm"
   # apply new dpi only if it's changed from the existing
   if [ "$existing_dpi" != "$future_dpi" ]; then
     convert -units PixelsPerInch -density "$dpi" "$figure" "$figure"
-    echo "File $figure converted to $dpi dpi"
+    echo "File $figure converted from $existing_dpi to $dpi dpi"
   fi
-# if the width is more than 144x14cm/2,54
-else
-  if [ "$width" -gt 793 ]; then
-    # set the new dpi in function of the image size
-    dpi=$(echo "scale=0; $width*2.54/14" | bc)
-    # convert dpi from pixelsperinch to pixelspercentimeter
-    dpi_cm=$(echo "scale=2; $dpi/2.54" | bc)
-    # read the existing dpi from figure as XX PixelsPerCentimeter
-    existing_dpi=$(identify -format "%x" "$figure")
-    # set the future dpi of figure as XX PixelsPerCentimeter
-    future_dpi="$dpi_cm PixelsPerCentimeter"
-    # apply new dpi only if it's changed from the existing
-    if [ "$existing_dpi" != "$future_dpi" ]; then
-      convert -units PixelsPerInch -density "$dpi" "$figure" "$figure"
-      echo "File $figure converted to $dpi dpi"
-    fi
-# for figures with width between 496px and 793px use a dpi of 144
-  else
-    dpi=144
-    # convert dpi from pixelsperinch to pixelspercentimeter
-    dpi_cm=$(echo "scale=2; $dpi/2.54" | bc)
-    # read the existing dpi from figure as XX PixelsPerCentimeter
-    existing_dpi=$(identify -format "%x" "$figure")
-    # set the future dpi of figure as XX PixelsPerCentimeter
-    future_dpi="$dpi_cm PixelsPerCentimeter"
-    # apply new dpi only if it's changed from the existing
-    if [ "$existing_dpi" != "$future_dpi" ]; then
-      convert -units PixelsPerInch -density 144 "$figure" "$figure"
-      echo "File $figure converted to 144 dpi"
-    fi
-  fi
-fi
 done
 rm list
 echo "Done!"


### PR DESCRIPTION
Ubuntu 16.04 identify utility in imagemagick Version: 8:6.8.9.9-7ubuntu5.1
returns an unrounded dpi and does not suffix it with (space)PixelsPerCentimeter