### PR TITLE
Bug 777891 - Provide ID Tag for Glossary and reference in Guide Overview Chapter

### DIFF
--- a/guide/C/ch_oview.xml
+++ b/guide/C/ch_oview.xml
@@ -406,6 +406,10 @@
 
     <itemizedlist>
        <listitem>
+          <para><xref linkend="gnc-gloss"></xref> - Glossary of terms used in <application>&app;</application></para>
+       </listitem>
+       
+       <listitem>
           <para><xref linkend="appendixa"></xref> - Guide for former <trademark
              class="registered">Quicken</trademark>, MS Money or other <acronym>QIF</acronym>
         users</para>

--- a/guide/C/gnc-glossary.xml
+++ b/guide/C/gnc-glossary.xml
@@ -7,7 +7,7 @@
   Translators:
                (translators put your name and email here)
 -->
-<glossary>
+<glossary id="gnc-gloss">
   <title><application>&app;</application> Glossary</title>
   <para>This is a glossary of common terms used in <application>&app;</application>.
   Some entries here are taken from Wikipedia (<ulink url="http://en.wikipedia.org"/>).</para>


### PR DESCRIPTION
This adds an ID tag to the Guide Glossary, and adds a reference to the Glossary in the Overview Chapter of the Guide.