### PR TITLE
L10N:de: weitere Korrekturen in Help_ch_GUIMenus.xml

### DIFF
--- a/help/de/Help_ch_GUIMenus.xml
+++ b/help/de/Help_ch_GUIMenus.xml
@@ -72,7 +72,7 @@
 
       <variablelist>
         <varlistentry>
-          <term>Titelleiste (en: Titlebar)</term>
+          <term>Titelleiste</term>
 
           <listitem>
             <para>Zeigt den Namen der aktuell geöffneten Datei und den Namen der aktiven Registerkarte an.
@@ -81,7 +81,7 @@
         </varlistentry>
 
         <varlistentry>
-          <term>Menüleiste (en: Menubar)</term>
+          <term>Menüleiste</term>
 
           <listitem>
             <para>Enthält die Menüs für das Kontenhierarchie-Fenster.
@@ -90,16 +90,16 @@
         </varlistentry>
 
         <varlistentry>
-          <term>Werkzeugleiste (en: Toolbar)</term>
+          <term>Werkzeugleiste</term>
 
           <listitem>
-            <para>Enthält Schaltflächen (Knöpfe) für den Zugriff auf typische kontenbezogene Funktionen.
+            <para>Enthält Schaltflächen (Knöpfe) für den Zugriff auf typische kontextbezogene Funktionen.
             </para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
-          <term>Registerkartenleiste (en: Tab bar)</term>
+          <term>Registerkartenleiste</term>
 
           <listitem>
             <para>Enthält die Kontenhierarchie, Kontenbücher sowie die geöffenen Berichte.
@@ -108,7 +108,7 @@
         </varlistentry>
 
         <varlistentry>
-          <term>Hauptfenster (en: Main pane)</term>
+          <term>Hauptfenster</term>
 
           <listitem>
             <para>Der Hauptanzeigebereich, mit dem Inhalt der aktuell ausgewählten Registerkarte
@@ -117,7 +117,7 @@
         </varlistentry>
 
         <varlistentry>
-          <term>Zusammenfassungs-Leiste (en: Summarybar)</term>
+          <term>Zusammenfassungs-Leiste</term>
 
           <listitem>
             <para>Enthält eine Kurzzusammenfassung der Finanzdaten.
@@ -126,7 +126,7 @@
         </varlistentry>
 
         <varlistentry>
-          <term>Statusleiste (en: Statusbar)</term>
+          <term>Statusleiste</term>
 
           <listitem>
             <para>Enthält eine Beschreibung des aktiven Menüpunkts und zeigt einen Fortschrittsbalken an.
@@ -286,7 +286,7 @@
                   </para>
                 </entry>
               </row>
-<!-- FIXME source: check the order and item -->
+
               <row>
                 <entry namest="c2">
                   <para><guimenuitem><accel>R</accel>echnungen importieren...</guimenuitem>
@@ -434,7 +434,7 @@
                   </para>
                 </entry>
               </row>
-<!-- TODO: Are the above descriptions really supposed to be blank? -->
+
               <row>
                 <entry>
                   <para><menuchoice>
@@ -770,7 +770,7 @@
                   </para>
                 </entry>
               </row>
-<!-- FIXME source: new item -->
+
               <row>
                 <entry>
                   <para><menuchoice>
@@ -789,7 +789,7 @@
                   </para>
                 </entry>
               </row>
-<!-- FIXMW source: new item -->
+
               <row>
                 <entry>
                   <para><guimenuitem>Konto<accel>e</accel>igenschaften übernehmen...</guimenuitem>
@@ -878,7 +878,7 @@
                     <menuchoice>
                       <guimenu>GnuCash</guimenu><guimenuitem>Einstellungen</guimenuitem>
                     </menuchoice>
-                    bei MacOS).
+                    bei &mac;).
                   </para>
                 </entry>
 
@@ -1285,7 +1285,7 @@
                   </para>
                 </entry>
               </row>
-<!-- FIXME source: This section is missing in the source -->
+
               <row>
                 <entry namest="c2">
                   <para><guimenuitem>Budget <accel>l</accel>öschen</guimenuitem>
@@ -1388,7 +1388,7 @@
 
                 <entry nameend="c3" namest="c2">
                   <para>Öffnet das Formular <guilabel>Posten im Konto</guilabel> .
-<!-- Additional details <xref linkend="view-lots"></xref> -->
+<!-- Zusätzliche Angaben <xref linkend="view-lots"></xref> -->
                   </para>
                 </entry>
               </row>
@@ -1623,7 +1623,7 @@
                   </para>
                 </entry>
               </row>
-<!-- FIXME source: new item -->
+
               <row>
                 <entry namest="c2">
                   <para><guimenuitem>Erinnerungen an <accel>f</accel>ällige Rechnungen</guimenuitem>
@@ -1746,7 +1746,7 @@
                   </para>
                 </entry>
               </row>
-<!-- FIXME source: new item -->
+
               <row>
                 <entry namest="c2">
                   <para><guimenuitem>Erinnerungen an <accel>f</accel>ällige Rechnungen</guimenuitem>
@@ -1846,7 +1846,7 @@
                   </para>
                 </entry>
               </row>
-<!-- FIXME source: new tem -->
+
               <row>
                 <entry>
                   <para><guimenuitem>Verknüpfte Geschäftsdokumente</guimenuitem>
@@ -1882,14 +1882,6 @@
                   </para>
                 </entry>
               </row>
-<!-- FIXME source: this menuitem is obsolet -->
-<!--              <row>
-                <entry><para><guimenuitem>Bills Due Reminder</guimenuitem></para></entry>
-
-                <entry namest="c2" nameend="c3">
-                 <para>View and edit the list of Bills Due Reminder.</para></entry>
-              </row>
--->
             </tbody>
           </tgroup>
         </table>
@@ -1907,7 +1899,8 @@
 
         <table frame="topbot" id="AccTree-ReportsMenu">
           <title>Kontenhierarchie - Berichte-Menu - Zugriff auf &app; Berichte und Diagramme</title>
-
+<!-- Translators: Attention, the menu items in GnuCash differ in the order between C and de.
+                  The actual sequence from the menu "Reports" is shown below. -->
           <tgroup align="left" cols="3">
             <colspec colname="c1"></colspec>
 
@@ -1930,7 +1923,6 @@
             </thead>
 
             <tbody>
-<!-- FIXME source: Check the order and entries -->
               <row>
                 <entry>
                   <para><menuchoice>
@@ -2819,7 +2811,7 @@
                   </para>
                 </entry>
               </row>
-<!-- FIXME source: new item -->
+
               <row>
                 <entry>
                   <para><guimenuitem><accel>I</accel>mport-Zuordnungen Editor</guimenuitem>
@@ -2832,7 +2824,7 @@
                   </para>
                 </entry>
               </row>
-<!-- FIXME source: new item -->
+
               <row>
                 <entry>
                   <para><guimenuitem>Buchungs<accel>v</accel>erknüpfungen</guimenuitem>
@@ -3013,14 +3005,21 @@
         <menuchoice>
           <guimenu>Ansicht</guimenu><guimenuitem>Werkzeugleiste</guimenuitem>
         </menuchoice>
-        ein- oder ausgeblendet werden. Die spezifischen Optionen, die in der
-        <emphasis>Werkzeugleiste</emphasis> angezeigt werden, variieren mit den Funktionen, die auf
-        der <quote>aktiven Registerkarte</quote> verfügbar sind.
+        ein- oder ausgeblendet werden.
       </para>
 
-      <para>Eine kurze Beschreibung der Funktion einer <emphasis>Werkzeug</emphasis>-Schaltfläche wird
-        angezeigt, wenn der Mauszeiger für einige Sekunden über dem Symbol platziert wird.
-      </para>
+      <note>
+        <para>Die spezifischen Optionen, die in der <emphasis>Werkzeugleiste</emphasis> angezeigt werden,
+          variieren mit den Funktionen, die auf der <quote>aktiven Registerkarte</quote> verfügbar
+          sind.
+        </para>
+      </note>
+
+      <tip>
+        <para>Eine kurze Beschreibung der Funktion einer <emphasis>Werkzeug</emphasis>-Schaltfläche wird
+          angezeigt, wenn der Mauszeiger für einige Sekunden über dem Symbol platziert wird.
+        </para>
+      </tip>
 
       <table frame="topbot" id="AccTree-ToolBarIcons">
         <title>Kontenhierarchie - <emphasis>Werkzeugleiste</emphasis></title>
@@ -3214,10 +3213,10 @@
   </sect1>
 
   <sect1 id="gui-acct-reg">
-    <title>Kontobuch/ Hauptbuch</title>
+    <title>Kontobuch/ Journal</title>
 
     <sect2 id="account-register">
-      <title>Fenster Kontobuch &amp; Hauptbuch</title>
+      <title>Fenster Kontobuch &amp; Journal</title>
 
       <para>Dieses Fenster dient der Eingabe und Bearbeitung Ihrer Kontodaten. Es bietet außerdem Werkzeuge zum
         Planen zukünftiger Geschäftsvorgänge, zum Suchen und Protokollieren von Buchungen und
@@ -3230,8 +3229,12 @@
         <menuchoice>
           <guimenu>Bearbeiten</guimenu> <guimenuitem>Konto öffnen</guimenuitem>
         </menuchoice>
-        . Dies öffnet ein neues Fenster mit dem gewähltem Kontobuch. Das Drücken von
-        <guibutton>Öffnen</guibutton> in der <emphasis>Werkzeugleiste</emphasis> im Fenster
+        oder betätigen Sie die
+        <keycombo>
+          <keycap>Strg</keycap> <keycap>O</keycap>
+        </keycombo>
+        Schaltfläche . Dies öffnet ein neues Fenster mit dem gewähltem Kontobuch. Das Drücken
+        von <guibutton>Öffnen</guibutton> in der <emphasis>Werkzeugleiste</emphasis> im Fenster
         <emphasis>Kontenhierarchie</emphasis> oder die Schaltfläche <guibutton>Springen</guibutton>
         im Fenster <emphasis>Kontobuch</emphasis> sind weiter Möglichkeiten.
       </para>
@@ -3264,7 +3267,7 @@
       <tip>
         <para>Das Aussehen der Anzeige eines Kontobuchs ist in hohem Maße konfigurierbar. (siehe
           <ulink
-url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.html#txns-regstyle1">
+url="https://www.gnucash.org/docs/v&series-stable;/de/gnucash-guide/chapter_txns.html#txns-regstyle1">
           Tutorial und Konzepte, Auswahl eines Registerstils</ulink>).
         </para>
       </tip>
@@ -3446,7 +3449,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
                 <entry namest="c2" nameend="c3">
                   <para>Optionsfeld zur Auswahl der Buchungsanzeige. Siehe
                     <ulink
-                    url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.html#txns-regstyle1">
+                    url="https://www.gnucash.org/docs/v&series-stable;/de/gnucash-guide/chapter_txns.html#txns-regstyle1">
                     Tutorial und Konzepte, Auswählen eines Registerstils</ulink>.
                   </para>
                 </entry>
@@ -3509,10 +3512,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
                 </entry>
 
                 <entry namest="c3">
-                  <para>Gewöhnliche Reihenfolge beibehalten:
-                  </para>
-
-                  <para>Buchungsdatum [Tag], Nummer, Eingabedatum [zweitens]
+                  <para>Gewöhnliche Reihenfolge beibehalten: Buchungsdatum [Tag], Nummer, Eingabedatum [zweitens]
                     <footnote>
                       <para>Das <quote>Eingabedatum</quote> ist normalerweise unsichtbar. Verwenden Sie einen Bericht, um es
                         anzuzeigen.
@@ -3901,7 +3901,8 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
 
                 <entry align="center" nameend="c3"
                 namest="c2">
-                  Beschreibung
+                  <para>Beschreibung
+                  </para>
                 </entry>
               </row>
             </thead>
@@ -4102,9 +4103,11 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
         </para>
       </note>
 
-      <para>Eine kurze Beschreibung der Funktion einer <emphasis>Werkzeug</emphasis>-Schaltfläche wird
-        angezeigt, wenn der Mauszeiger für einige Sekunden über dem Symbol platziert wird.
-      </para>
+      <tip>
+        <para>Eine kurze Beschreibung der Funktion einer <emphasis>Werkzeug</emphasis>-Schaltfläche wird
+          angezeigt, wenn der Mauszeiger für einige Sekunden über dem Symbol platziert wird.
+        </para>
+      </tip>
 
       <table frame="topbot" id="Trans-ToolBarIcons">
         <title>Kontobuch (Buchungsansicht) <emphasis>Werkzeugleiste</emphasis></title>
@@ -4342,25 +4345,6 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
         <xref linkend="Common-status-bar" /> beschrieben.
       </para>
     </sect2>
-<!--  FIXME source -->
-<!-- FIXME de: auf Aktualität prüfen
-    <sect2 id="reg-gl">
-      <title>Hauptbuch</title>
-
-        <para>Das Hauptbuch stellt ein erweitertes Kontobuch dar, mit dem Sie Geschäftsvorgänge
-        eingeben können, ohne einzelne Konten öffnen zu müssen. Die Buchungseinträge aller
-        Konten werden hier in einem einzigen Kontobuch dargestellt.</para>
-        <para />
-        <para>Die Eingabe von Geschäftsvorgängen im Hauptbuch ist etwas komplizierter
-        als die Eingabe im Kontobuch des jeweiligen Kontos. Der Vorteil ist jedoch,
-        dass das Hauptbuch eine umfassendere Sicht auf die Geschäftsvorgänge in allen Konten bietet.</para>
-        <para />
-        <para>Standardmäßig werden im Hauptbuch nur die Geschäftsvorgänge des letzten
-        Monats angezeigt. Sie können dies über den Menüpunkt
-        <menuchoice><guimenu>Ansicht</guimenu><guimenuitem>Filter nach...</guimenuitem></menuchoice>
-        den Datumsbereich eingrenzen.</para>
-    </sect2>
--->
   </sect1>
 
   <sect1 id="gui-report">
@@ -4495,7 +4479,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
 
                 <entry namest="c3">
                   <para>Exportiert den aktuellen Bericht in eine Datei. Als Export-Format stehen <acronym>HTML</acronym> und
-                    <acronym>CSV</acronym> zur Verfügung.
+                    <acronym>HTML</acronym> zur Verfügung.
                   </para>
                 </entry>
               </row>
@@ -4578,9 +4562,8 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
       <sect3 id="Report-actions-menu">
         <title>Berichte - <guimenu>A<accel>k</accel>tionen</guimenu>-Menü</title>
 
-        <para>Wenn Sie in der <emphasis>Menüleiste</emphasis> auf <guimenu>Aktionen</guimenu> klicken, wird das
-          Menü mit den in <xref linkend="AccTree-ActionsMenu"/> beschriebenen Auswahlmöglichkeiten
-          geöffnet.
+        <para>Die im Menü <guimenu>Aktionen</guimenu> angezeigten Elemente sind die gleichen wie in
+          <xref linkend="AccTree-ActionsMenu"/>.
         </para>
 
         <para>Der Umfang an Menüpunkte ist jedoch erheblich reduziert.
@@ -4671,7 +4654,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
                   <para>Speichert die aktuelle Berichtskonfiguration unter einem neuen Namen. Sie können den Bericht erneut
                     öffnen, indem Sie die Funktion
                     <menuchoice>
-                      <guimenu>Berichte </guimenu><guimenuitem>Gespeicherte Berichtskonfigurationen
+                      <guimenu>Berichte</guimenu><guimenuitem>Gespeicherte Berichtskonfigurationen
                       </guimenuitem>
                     </menuchoice>
                     aufrufen.
@@ -4727,9 +4710,11 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
         </para>
       </note>
 
-      <para>Eine kurze Beschreibung der Funktion einer <emphasis>Werkzeug</emphasis>-Schaltfläche wird
-        angezeigt, wenn der Mauszeiger für einige Sekunden über dem Symbol platziert wird.
-      </para>
+      <tip>
+        <para>Eine kurze Beschreibung der Funktion einer <emphasis>Werkzeug</emphasis>-Schaltfläche wird
+          angezeigt, wenn der Mauszeiger für einige Sekunden über dem Symbol platziert wird.
+        </para>
+      </tip>
 
       <table frame="topbot">
         <title>Berichte - <emphasis>Werkzeugleiste</emphasis></title>
@@ -4891,7 +4876,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
 
               <entry>
                 <para>Exportiert den aktuellen Bericht in eine Datei. Als Export-Format stehen <acronym>HTML</acronym> und
-                  <acronym>CSV</acronym> zur Verfügung.
+                  <acronym>HTML</acronym> zur Verfügung.
                 </para>
               </entry>
             </row>
@@ -4991,6 +4976,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
         öffnet sich ein weiters <guilabel>Abgleichen</guilabel> Fenster, in dem Sie Gutschrift und
         Belastung mit Ihrem Kontoauszug vergleichen können.
       </para>
+
 <!-- TODO: insert Screenshot -->
 <!-- 
       <figure>
@@ -4998,7 +4984,8 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
         
       </figure>
 -->
-       <sect3 id="Tools-reconcile-win">
+
+      <sect3 id="Tools-reconcile-win">
         <title>Abgleichen - Fenster</title>
 
         <table frame="topbot" id="Tools-ReconcileWin">
@@ -5093,10 +5080,10 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
         Menüpunkte.
       </para>
 
-      <sect3 id="tool-reconcile-menu">
+      <sect3 id="Tools-reconcile-menu">
         <title>Abgleichen - <guimenu><accel>A</accel>bgleichen</guimenu>-Menü</title>
 
-        <table frame="topbot" id="tool-ReconcileMenu">
+        <table frame="topbot" id="Tools-ReconcileMenu">
           <title>Abgleichen - Abgleichen-Menü - Informationen zum Abgleich sowie Fertigstellen und Unterbrechen.</title>
 
           <tgroup cols="2">
@@ -5179,10 +5166,10 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
         </table>
       </sect3>
 
-      <sect3 id="tool-reconcile-account">
+      <sect3 id="Tools-reconcile-account">
         <title>Abgleichen - <guimenu><accel>K</accel>onto</guimenu>-Menü</title>
 
-        <table frame="topbot" id="tool-ReconcileAccount">
+        <table frame="topbot" id="Tools-ReconcileAccount">
           <title>Abgleichen - Konto-Menü - Kontenfunktionen</title>
 
           <tgroup cols="2">
@@ -5260,10 +5247,10 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
         </table>
       </sect3>
 
-      <sect3 id="tool-reconcile-trans">
+      <sect3 id="Tools-reconcile-trans">
         <title>Abgleichen - <guimenu><accel>B</accel>uchung</guimenu>-Menü</title>
 
-        <table frame="topbot" id="tool-ReconcileTrans">
+        <table frame="topbot" id="Tools-ReconcileTrans">
           <title>Abgleichen - Buchung-Menü - Funktionen zur Bearbeitung von Geschäftsvorgängen</title>
 
           <tgroup cols="2">
@@ -5331,7 +5318,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
                 </entry>
 
                 <entry>
-                  <para>Ausgewählte Buchungen abgleichen.
+                  <para>Abgleichen der ausgewählten Buchungen.
                   </para>
                 </entry>
               </row>
@@ -5350,7 +5337,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
                 </entry>
 
                 <entry>
-                  <para>Ausgewählten Buchungssatz nicht abgleichen.
+                  <para>Nimmt den Abgleich der ausgewählten Buchungen zurück.
                   </para>
                 </entry>
               </row>
@@ -5377,10 +5364,10 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
         </table>
       </sect3>
 
-      <sect3 id="tool-reconcile-help">
+      <sect3 id="Tools-reconcile-help">
         <title>Abgleichen - <guimenu><accel>H</accel>ilfe</guimenu>-Menü</title>
 
-        <table frame="topbot" id="tool-ReconcileHelp">
+        <table frame="topbot" id="Tools-ReconcileHelp">
           <title>Agbleichen - Hilfe-Menü - Diese Hilfe sowie das Dokument &app;-Kurs und Konzepte</title>
 
           <tgroup cols="2">
@@ -5419,7 +5406,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
     <sect2 id="reconcile-toolbar">
       <title>Abgleichen - <emphasis>Werkzeugleiste</emphasis>, Symbole/Schaltflächen</title>
 
-      <para>Das Abgleichenfenster verfügt über eine Reihe von Schaltflächen in der
+      <para>Das <guilabel>Abgleichen</guilabel>-fenster verfügt über eine Reihe von Schaltflächen in der
         <emphasis>Werkzeugleiste</emphasis> um schnell auf einige allgemeine Funktionen zuzugreifen,
         die mit der jeweils aktiven Registerkarte interagieren.
       </para>
@@ -5430,18 +5417,20 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
         </para>
       </note>
 
-      <tip>
+      <note>
         <para>Einige Schaltflächen in der <emphasis>Werkzeugleiste</emphasis> werden erst aktiv sobald in dem
           <quote>Abgleichenfenster</quote> eine Buchung markiert ist.
         </para>
+      </note>
+
+      <tip>
+        <para>Eine kurze Beschreibung der Funktion einer <emphasis>Werkzeug</emphasis>-Schaltfläche wird
+          angezeigt, wenn der Mauszeiger für einige Sekunden über dem Symbol platziert wird.
+        </para>
       </tip>
 
-      <para>Eine kurze Beschreibung der Funktion einer <emphasis>Werkzeug</emphasis>-Schaltfläche wird
-        angezeigt, wenn der Mauszeiger für einige Sekunden über dem Symbol platziert wird.
-      </para>
-
-      <table frame="topbot" id="tool-ReconcileToolbar">
-        <title>Abgleichen <emphasis>Werkzeugleiste</emphasis></title>
+      <table frame="topbot" id="Tools-ReconcileToolbar">
+        <title>Abgleichen - <emphasis>Werkzeugleiste</emphasis></title>
 
         <tgroup cols="2">
           <thead>
@@ -5490,7 +5479,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
               </entry>
 
               <entry>
-                <para>Ausgewählte Buchungen abgleichen.
+                <para>Abgleichen der ausgewählten Buchungen.
                 </para>
               </entry>
             </row>
@@ -5502,7 +5491,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
               </entry>
 
               <entry>
-                <para>Ausgewählten Buchungssatz nicht abgleichen.
+                <para>Nimmt den Abgleich der ausgewählten Buchungen zurück.
                 </para>
               </entry>
             </row>
@@ -5568,7 +5557,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
               </entry>
 
               <entry>
-                <para>Die Abstimmung dieses Kontos abbrechen.
+                <para>Den Abgleich dieses Kontos abbrechen.
                 </para>
               </entry>
             </row>
@@ -5584,10 +5573,11 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
     <sect2 id="trans-SX-display">
       <title>Ansicht für Terminierte Buchungen</title>
 
-      <tip>
+      <note>
         <para>Die Arbeitsweise mit terminierten Buchungen wird in <xref linkend="trans-sched"></xref> beschrieben.
         </para>
-      </tip>
+      </note>
+
 <!-- TODO: insert Screenshot -->
 <!-- 
       <figure>
@@ -5595,7 +5585,8 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
         
       </figure>
 -->
-       <para>Dieses Ansicht wird geöffnet, wenn
+
+      <para>Dieses Ansicht wird geöffnet, wenn
         <menuchoice>
           <guimenu>Aktionen</guimenu> <guisubmenu>Terminierte
           Buchungen</guisubmenu><guimenuitem>Terminierte Buchungen Editor</guimenuitem>
@@ -5796,9 +5787,11 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
         verwendet werden.
       </para>
 
-      <para>Eine kurze Beschreibung der Funktion einer <emphasis>Werkzeug</emphasis>-Schaltfläche wird
-        angezeigt, wenn der Mauszeiger für einige Sekunden über dem Symbol platziert wird.
-      </para>
+      <tip>
+        <para>Eine kurze Beschreibung der Funktion einer <emphasis>Werkzeug</emphasis>-Schaltfläche wird
+          angezeigt, wenn der Mauszeiger für einige Sekunden über dem Symbol platziert wird.
+        </para>
+      </tip>
 
       <table frame="topbot">
         <title>Terminierte Buchungen - <emphasis>Werkzeugleiste</emphasis></title>
@@ -5888,10 +5881,10 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
       </table>
     </sect2>
   </sect1>
- 
+
   <sect1 id="gui-budget">
     <title>Budget</title>
- 
+
     <sect2 id="budget-menus">
       <title>Budget - Menüleiste</title>
 
@@ -6000,14 +5993,8 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
 
         <table frame="topbot" id="budget-menus-actions-items">
           <title>Budget - Aktionen-Menü - Einträge im Standardmenü die sich auf Budgets beziehen.</title>
-<!-- FIXME source: number of columns -->
-          <tgroup align="left" cols="3">
-            <colspec colname="c1"></colspec>
 
-            <colspec colname="c2"></colspec>
-
-            <colspec colname="c3"></colspec>
-
+          <tgroup cols="2">
             <thead>
               <row>
                 <entry>
@@ -6034,11 +6021,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
                 <entry align="center">
                   <para>Öffnet das Untermenü Budget zur Auswahl von Budgetaktionen.
                   </para>
-                </entry>
-              </row>
 
-              <row>
-                <entry align="left" namest="c2" nameend="c3">
                   <tip>
                     <para>Die Menüpunkte, die zur Planung von Budgets gebraucht werden, sind ausführlich in
                       <xref linkend="AccTree-ActionsMenu"></xref> beschrieben.
@@ -6071,14 +6054,8 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
 
         <table frame="topbot" id="budget-menus-reports-items">
           <title>Budget - Berichte-Menü - Einträge im Standardmenü, die sich auf Budgets beziehen</title>
-<!-- FIXME source: number of columns -->
-          <tgroup align="left" cols="3">
-            <colspec colname="c1"></colspec>
 
-            <colspec colname="c2"></colspec>
-
-            <colspec colname="c3"></colspec>
-
+          <tgroup cols="2">
             <thead>
               <row>
                 <entry>
@@ -6086,9 +6063,9 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
                   </para>
                 </entry>
 
-                <entry align="center" nameend="c3"
-                namest="c2">
-                  Beschreibung
+                <entry align="center">
+                  <para>Beschreibung
+                  </para>
                 </entry>
               </row>
             </thead>
@@ -6102,14 +6079,10 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
                   </para>
                 </entry>
 
-                <entry align="center" nameend="c3" namest="c2">
+                <entry align="center">
                   <para>Öffnet das Untermenü "Budget" zur Auswahl eines Budgetberichts.
                   </para>
-                </entry>
-              </row>
 
-              <row>
-                <entry align="left" namest="c2" nameend="c3">
                   <tip>
                     <para>Die Menüpunkte, die zur Anzeige von Budgetberichten vorhanden sind, sind ausführlich in
                       <xref linkend="AccTree-ReportsMenu"></xref> beschrieben.
@@ -6130,9 +6103,11 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
         <emphasis>Werkzeugleiste</emphasis> die zur Budgetierung gebraucht werden.
       </para>
 
-      <para>Eine kurze Beschreibung der Funktion einer <emphasis>Werkzeug</emphasis>-Schaltfläche wird
-        angezeigt, wenn der Mauszeiger für einige Sekunden über dem Symbol platziert wird.
-      </para>
+      <tip>
+        <para>Eine kurze Beschreibung der Funktion einer <emphasis>Werkzeug</emphasis>-Schaltfläche wird
+          angezeigt, wenn der Mauszeiger für einige Sekunden über dem Symbol platziert wird.
+        </para>
+      </tip>
 
       <table frame="topbot">
         <title>Budget <emphasis>Werkzeugleiste</emphasis></title>
@@ -6181,7 +6156,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
                 </para>
               </entry>
             </row>
-<!-- FIXME source: new item -->
+
             <row>
               <entry>
                 <para><guibutton>Öffnen</guibutton>
@@ -6237,7 +6212,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
                 <para><guibutton>Löschen</guibutton>
                 </para>
               </entry>
-<!-- FIXME source: new item -->
+
               <entry>
                 <para>Das gewählte Budget löschen.
                 </para>
@@ -6289,7 +6264,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
         </step>
 
         <step>
-          <para>Drücke
+          <para>Betätige
             <keycombo>
               <keycap>Enter</keycap>
             </keycombo>
@@ -6377,7 +6352,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
   </sect1>
 
   <sect1 id="gui-bussiness">
-    <title>Geschäft</title>
+    <title>Geschäftliches</title>
 
     <sect2 id="business-customer-overview">
       <title>Kundenübersicht</title>
@@ -6457,7 +6432,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
                 </para>
               </entry>
             </row>
-<!--  FIXME source: new item -->
+
             <row>
               <entry>
                 <para><guibutton>Zahlung verarbeiten</guibutton>
@@ -6540,7 +6515,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
                 </para>
               </entry>
             </row>
-<!-- FIXME source: new item -->
+
             <row>
               <entry>
                 <para><guimenuitem>Zahlung verarbeiten</guimenuitem>
@@ -6641,7 +6616,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
                 </para>
               </entry>
             </row>
-<!-- FIXME source: new item -->
+
             <row>
               <entry>
                 <para><guibutton>Zahlung verarbeiten</guibutton>
@@ -6724,7 +6699,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
                 </para>
               </entry>
             </row>
-<!-- FIXME source: new item -->
+
             <row>
               <entry>
                 <para><guimenuitem>Zahlung verarbeiten</guimenuitem>
@@ -6813,7 +6788,7 @@ url="https://www.gnucash.org/docs/v&series-stable;/C/gnucash-guide/chapter_txns.
                 </para>
               </entry>
             </row>
-<!-- FIXME source: new item -->
+
             <row>
               <entry>
                 <para><guibutton>Zahlung verarbeiten</guibutton>


### PR DESCRIPTION
* entfernen von überflüssigen Leerzeichen
* entfernen der dritten Tabellenspalte aus zwei Tabellen im Bereich
"Budget"
* entfernen von Verweisen auf die englischsprachigen Elemente im Bild
"Main-window-callouts.png"
* entfernen der FIXME- Einträge nach dem Backport in help/C