### PR TITLE
Replace misused acronyms with guilabels.

### DIFF
--- a/guide/C/ch_accts.xml
+++ b/guide/C/ch_accts.xml
@@ -425,7 +425,7 @@ Translators:
         <xref linkend="chapter_currency" /> for more information.
       </para>
 
-      <para><emphasis>Money Market</emphasis> and <emphasis>Credit Line </emphasis>are used only in the OFX
+      <para><emphasis>Money Market</emphasis> and <emphasis>Credit Line</emphasis> are used only in the OFX
         importer, apparently for completeness with the specification.
       </para>
     </sect3>

--- a/guide/C/ch_basics.xml
+++ b/guide/C/ch_basics.xml
@@ -483,7 +483,7 @@ Translators:
         in the <guilabel>Welcome to &appname;!</guilabel> menu, or when you select <menuchoice>
           <shortcut>
           <keycombo>
-            <keycap>Strg</keycap><keycap>N</keycap>
+            <keycap>Ctrl</keycap><keycap>N</keycap>
           </keycombo>
           </shortcut> <guimenu><accel>F</accel>ile</guimenu><guimenuitem><accel>N</accel>ew
           File</guimenuitem>
@@ -510,7 +510,7 @@ Translators:
             These items are explained elsewhere in the Guide, and can be changed at any time from <menuchoice>
               <shortcut>
               <keycombo>
-                <keycap>Strg</keycap><keycap>Enter</keycap>
+                <keycap>Ctrl</keycap><keycap>Enter</keycap>
               </keycombo>
               </shortcut>
               <guimenu><accel>F</accel>ile</guimenu><guimenuitem>Proper<accel>t</accel>ies</guimenuitem>
@@ -603,7 +603,7 @@ Translators:
             the process, back up to change something, or apply to confirm your choices. If you're
             creating a new book, &app; will present a dialog to select a backend and either a file
             to save it or database server, database name, and credentials to create a MySQL or
-            Postgresql database if GnuCash was built with those features and you have the necessary
+            PostgreSQL database if GnuCash was built with those features and you have the necessary
             dependencies installed.
           </para>
 
@@ -868,9 +868,9 @@ Translators:
       <para>All of the menu items have access keys which are marked by underlined characters in the menu names.
         Pressing the <keycap>Alt</keycap> key with the underlined character in the menu heading will
         bring up the menu items for that heading. Once the menu items are displayed, type the
-        underlined character in the menu item to activate it. For example, typing<keycombo>
+        underlined character in the menu item to activate it. For example, typing <keycombo>
           <keycap>Alt</keycap><keycap>F</keycap>
-        </keycombo>in the main window brings up the <guimenu>File</guimenu> menu, then typing <keycap>S</keycap> will
+        </keycombo> in the main window brings up the <guimenu>File</guimenu> menu, then typing <keycap>S</keycap> will
         save the file. Access keys are fixed and cannot be changed by users.
       </para>
 

--- a/guide/C/ch_basics.xml
+++ b/guide/C/ch_basics.xml
@@ -1156,7 +1156,7 @@ Translators:
 
         <listitem>
           <para>Select the <guilabel>Data Format</guilabel> of the file you are saving from the drop down list. The
-            default selection is <acronym>XML</acronym> but if you have set up a database back end
+            default selection is <guilabel>xml</guilabel> but if you have set up a database back end
             you can change to that format.
           </para>
 
@@ -1166,16 +1166,16 @@ Translators:
         </listitem>
 
         <listitem>
-          <para></para>
 
           <itemizedlist>
             <listitem>
-              <para>If you selected <acronym>XML</acronym> or <acronym>sqlite3</acronym> you will see a screen like
+              <para>If you selected <guilabel>xml</guilabel> or <guilabel>sqlite3</guilabel> you will see a screen like
                 this:
               </para>
 
               <figure>
-                <title>Save screen when <acronym>XML</acronym> or <acronym>sqlite3</acronym> is selected.</title><screenshot id="basics-SaveXML">
+                <title>Save screen when <guilabel>xml</guilabel> or <guilabel>sqlite3</guilabel> is selected.</title>
+                <screenshot id="basics-SaveXML">
                   <mediaobject>
                     <imageobject role="html">
                       <imagedata fileref="figures/basics_SaveXML.png" format="PNG"
@@ -1193,7 +1193,7 @@ Translators:
 
                     <caption>
                       <para>This image shows the <guilabel>Save</guilabel> screen when the selected <guilabel>Data
-                        Format</guilabel> is <acronym>XML</acronym> or <acronym>sqlite3</acronym>.
+                        Format</guilabel> is <guilabel>xml</guilabel> or <guilabel>sqlite3</guilabel>.
                       </para>
                     </caption>
                   </mediaobject>
@@ -1226,12 +1226,13 @@ Translators:
             </listitem>
 
             <listitem>
-              <para>If you selected <acronym>mysql</acronym> or <acronym>postgres</acronym> <guilabel>Data
-                Format</guilabel> you will see a screen like this:
+              <para>If you selected <guilabel>mysql</guilabel> or <guilabel>postgres</guilabel> <guilabel>Data
+                Format</guilabel>, you will see a screen like this:
               </para>
 
               <figure>
-                <title>Save screen when <acronym>mysql</acronym> or <acronym>postgres</acronym> is selected.</title><screenshot id="basics-SaveSQL">
+                <title>Save screen when <guilabel>mysql</guilabel> or <guilabel>postgres</guilabel> is selected.</title>
+                <screenshot id="basics-SaveSQL">
                   <mediaobject>
                     <imageobject role="html">
                       <imagedata fileref="figures/basics_SaveSQL.png" format="PNG"
@@ -1249,8 +1250,8 @@ Translators:
 
                     <caption>
                       <para>This image shows the <guilabel>Save</guilabel> screen when the selected <guilabel>Data
-                        Format</guilabel> is <acronym>mysql</acronym> or
-                        <acronym>postgres</acronym>.
+                        Format</guilabel> is <guilabel>mysql</guilabel> or
+                        <guilabel>postgres</guilabel>.
                       </para>
                     </caption>
                   </mediaobject>
@@ -1263,7 +1264,7 @@ Translators:
               </para>
 
               <warning>
-                <para>Saving to <acronym>mysql</acronym> or <acronym>postgres</acronym> requires the proper permissions in
+                <para>Saving to <guilabel>mysql</guilabel> or <guilabel>postgres</guilabel> requires the proper permissions in
                   that database, that is you need to have the permissions to create a new database
                   with the given database name, or you need to have write access to an existing
                   database with the given database name.

--- a/guide/C/ch_txns.xml
+++ b/guide/C/ch_txns.xml
@@ -353,9 +353,9 @@
         <listitem>
           <para>All of the menu items have access keys defined, and these are marked by underlined characters in the
             menu names. Press <keycap>Alt</keycap> + [underlined character] to bring up the menu,
-            then select an item by typing its underlined character. For example, typing<keycombo>
+            then select an item by typing its underlined character. For example, typing <keycombo>
               <keycap>Alt</keycap> <keycap>A</keycap>
-            </keycombo>brings up the Actions menu, then typing <keycap>P</keycap> will split the transaction. A few of the
+            </keycombo> brings up the Actions menu, then typing <keycap>P</keycap> will split the transaction. A few of the
             menu items also have shortcut keys that immediately invoke the command (typically using
             the <keycap>Ctrl</keycap> key). These shortcuts are listed next to the item.
           </para>
@@ -367,9 +367,9 @@
 
           <itemizedlist>
             <listitem>
-              <para><keycap>Tab</keycap> to move to the next field,<keycombo>
+              <para><keycap>Tab</keycap> to move to the next field, <keycombo>
                   <keycap>Shift</keycap> <keycap>Tab</keycap>
-                </keycombo>to move to the previous field
+                </keycombo> to move to the previous field
               </para>
             </listitem>
 
@@ -393,9 +393,9 @@
             <listitem>
               <para><keycombo>
                   <keycap>Shift</keycap> <keycap>Page Up</keycap>
-                </keycombo>to go to the first transaction,<keycombo>
+                </keycombo> to go to the first transaction, <keycombo>
                   <keycap>Shift</keycap> <keycap>Page Down</keycap>
-                </keycombo>to go to the last transaction
+                </keycombo> to go to the last transaction
               </para>
             </listitem>
           </itemizedlist>
@@ -407,9 +407,9 @@
 
       <itemizedlist>
         <listitem>
-          <para><keycap>Tab</keycap> moves to the next box and<keycombo>
+          <para><keycap>Tab</keycap> moves to the next box and <keycombo>
               <keycap>Shift</keycap><keycap>Tab</keycap>
-            </keycombo>moves to the previous box
+            </keycombo> moves to the previous box
           </para>
         </listitem>
 
@@ -1029,7 +1029,7 @@
       create it for you.
     </para>
 
-    <para>In this howto, we&rsquo;ll take a monthly Internet subscription of 20 USD as example, which is taken
+    <para>In this how-to, we&rsquo;ll take a monthly Internet subscription of 20 USD as example, which is taken
       on the 28th of each month.
     </para>
 


### PR DESCRIPTION
Replace misused acronyms with guilabels.
Add spaces between words and tags to avoid word concatenation.
Change German word Strg to English word Ctrl.
Fix typos.