### PR TITLE
Proposal: Remove obsolete Appendices pages (FAQ, VAT, AUX file format)

### DIFF
--- a/guide/C/ch_oview.xml
+++ b/guide/C/ch_oview.xml
@@ -489,21 +489,6 @@
       </listitem>
 
       <listitem>
-        <para><xref linkend="appendixb"></xref>
-        </para>
-      </listitem>
-
-      <listitem>
-        <para><xref linkend="appendixc"></xref>
-        </para>
-      </listitem>
-
-      <listitem>
-        <para><xref linkend="appendixd"></xref>
-        </para>
-      </listitem>
-
-      <listitem>
         <para><xref linkend="fdl"></xref>
         </para>
       </listitem>

--- a/guide/C/ch_oview.xml
+++ b/guide/C/ch_oview.xml
@@ -542,23 +542,35 @@
       <title>&app; Website</title>
 
       <para>The <ulink
-      url="http://www.gnucash.org"><citetitle>&appname;</citetitle></ulink> website
+      url="&url-www;"><citetitle>&appname;</citetitle></ulink> website
         contains helpful information about the program and about any updates to it. It also contains
         links to other online resources.
       </para>
     </sect2>
 
     <sect2 id="wiki">
-      <title>&app; Wiki</title>
+      <title id="wiki.title">&app; Wiki</title>
 
       <para>An immense amount of less-formal documenation, both of &app; itself and its maintenance and
-        development may be found in the <ulink
-     url="https://wiki.gnucash.org/wiki">&app;
-        Wiki</ulink>; the <ulink
-     url="https://wiki.gnucash.org/wiki/FAQ">Frequently Asked
-        Questions</ulink> page should be a first stop whenever you encounter difficulty using &app;.
+        development may be found in the <ulink url="&url-wiki;">&app; Wiki</ulink>.
       </para>
     </sect2>
+        
+    <sect2 id="oview-faq">
+        <title>&app; Frequently Asked Questions</title>    
+
+        <para>
+            <ulink url="&url-wiki-faq;">&app; Frequently Asked Questions</ulink> (<acronym>FAQ</acronym>) page 
+            is also on the <xref linkend="wiki" endterm="wiki.title" />.
+            It should be a first stop whenever you encounter difficulty using &app;.
+            It is now translated into German and Simplified Chinese. If you'd like to access to the translated page,
+            see tabs on the top of the <ulink url="&url-wiki-faq;">&app; Frequently Asked Questions</ulink> page.
+
+        </para>
+    
+    </sect2>
+        
+        
 
     <sect2 id="on-line-assistance">
       <title>&app; On-line Assistance</title>

--- a/guide/C/gnucash-guide.xml
+++ b/guide/C/gnucash-guide.xml
@@ -657,12 +657,6 @@
 
     <xi:include href="appendixa.xml" />
 
-    <xi:include href="appendixb.xml" />
-
-    <xi:include href="appendixc.xml" />
-
-    <xi:include href="appendixd.xml" />
-
     <xi:include href="fdl-appendix.xml" />
   </part>
 </book>


### PR DESCRIPTION
I think FAQ, VAT, AUX file format pages in the concepts guide is too old and obsolete.
So I suggest removing them.

I only work some important locations.
If you agree, I will edit other files like cmake.