### PR TITLE
Proposal: Move chapter Depreciation before Other Assets.

### DIFF
--- a/guide/C/ch_oview.xml
+++ b/guide/C/ch_oview.xml
@@ -449,12 +449,12 @@
         </listitem>
 
         <listitem>
-          <para><xref linkend="chapter_other_assets"></xref>
+          <para><xref linkend="chapter_dep"></xref>
           </para>
         </listitem>
 
         <listitem>
-          <para><xref linkend="chapter_dep"></xref>
+          <para><xref linkend="chapter_other_assets"></xref>
           </para>
         </listitem>
 

--- a/guide/C/gnucash-guide.xml
+++ b/guide/C/gnucash-guide.xml
@@ -641,9 +641,9 @@
 
     <xi:include href="ch_budgets.xml" />
 
-    <xi:include href="ch_oth_assets.xml" />
-
     <xi:include href="ch_dep.xml" />
+
+    <xi:include href="ch_oth_assets.xml" />
 
     <xi:include href="ch_python_bindings.xml" />
 


### PR DESCRIPTION
I read both the Depreciation chapter and the Other Assets chapter.
The Depreciation chapter focus on the topic of depreciation only, and the usages of GnuCash on depreciation is described clearly. 
On the other hand, the Other Assets chapter describes many assets and they are a little abstract.

So I think it is better that we move the Depreciation capter before the Other Assets chapter. 