### PR TITLE
Improved PDF creation with the "variablelist" element

### DIFF
--- a/cmake/AddPdfTarget.cmake
+++ b/cmake/AddPdfTarget.cmake
@@ -24,6 +24,7 @@ function (add_pdf_target docname lang entities figures)
         COMMAND ${XSLTPROC} ${XSLTPROCFLAGS} ${XSLTPROCFLAGS_FO}
                             -o "${CMAKE_CURRENT_BINARY_DIR}/${fofile}"
                             --stringparam fop1.extensions 1
+                            --stringparam variablelist.as.blocks 1
                             "${CMAKE_SOURCE_DIR}/xsl/1.79.2/fo/docbook.xsl"
                             "${CMAKE_CURRENT_SOURCE_DIR}/${docname}.xml"
         DEPENDS ${entities} "${docname}.xml" "${CMAKE_SOURCE_DIR}/docbook/gnc-docbookx.dtd")


### PR DESCRIPTION
Using the parameter "variablelist.as.blocks" the term and its
description are not printed on the same line. The term itself hangs to
the left and the description is printed one line below.