### PR TITLE
Workaround patch for install gnc-locale-${lang}.dtd for CMake.

### DIFF
--- a/cmake/AddGHelpTarget.cmake
+++ b/cmake/AddGHelpTarget.cmake
@@ -18,7 +18,13 @@ function (add_ghelp_target docname lang entities figures)
     foreach(xml_file ${entities} ${docname}.xml)
         list(APPEND source_files "${CMAKE_CURRENT_SOURCE_DIR}/${xml_file}")
     endforeach()
-    list(APPEND source_files "${CMAKE_SOURCE_DIR}/docbook/gnc-docbookx.dtd")
+
+    set(dtd_files "${CMAKE_SOURCE_DIR}/docbook/gnc-docbookx.dtd"
+                  "${CMAKE_SOURCE_DIR}/docbook/gnc-locale-C.dtd"
+                  "${CMAKE_SOURCE_DIR}/docbook/gnc-locale-${lang}.dtd")
+    list(REMOVE_DUPLICATES dtd_files)
+    list(APPEND source_files ${dtd_files})
+
 
     set(dest_files "")
     foreach(xml_file ${entities} ${docname}.xml gnc-docbookx.dtd)
@@ -28,7 +34,7 @@ function (add_ghelp_target docname lang entities figures)
     add_custom_command(
         OUTPUT ${dest_files}
         COMMAND ${CMAKE_COMMAND} -E copy ${source_files} "${BUILD_DIR}"
-        DEPENDS ${entities} "${docname}.xml" "${CMAKE_SOURCE_DIR}/docbook/gnc-docbookx.dtd"
+        DEPENDS ${entities} "${docname}.xml" ${dtd_files}
         WORKING_DIRECTORY "${BUILD_DIR}")
 
     # Copy figures for this document

--- a/xmldocs.make
+++ b/xmldocs.make
@@ -48,7 +48,7 @@ otherdocdir = $(docdir)/$(lang)
 
 # ************** Rules to install xml files for gnome-help ***********************
 
-xml_files = $(entities) $(docname).xml $(top_srcdir)/docbook/gnc-docbookx.dtd
+xml_files = $(entities) $(docname).xml $(top_srcdir)/docbook/*.dtd
 gnomehelp_DATA =  $(xml_files)
 gnomehelpfiguresdir = $(gnomehelpdir)/$(figdir)
 gnomehelpfigures_DATA = $(shell ls ${srcdir}/${figdir}/*.png)


### PR DESCRIPTION
Conflict PR #211
---
This patch is for PR #207.

cmake -S gnucash-docs -B .
cmake --build . --target ghelp
cmake --install . --prefix ${prefix}

Then ghelp will be installed under ${prefix}/share/gnome/help/ with correct dtd files.