### PR TITLE
L10N:de: Anpassen der Bildelemente

### DIFF
--- a/manual/de/Help_ch_GettingStarted.xml
+++ b/manual/de/Help_ch_GettingStarted.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter SYSTEM "gnc-locale-de.dtd">
 <!-- (Do not remove this comment block.)
-Version: 2.0.2
-Last modified: January 2011
+Version: 4.6
+Last modified: September 2021
+  modified: January 2011
   modified: November 18th 2010
   modified: April 23th 2007
   modified: July 9th 2006
@@ -34,7 +35,7 @@ Translators:
       <title>Der <quote>Willkommen in &appname;!</quote>-Dialog</title><screenshot>
         <mediaobject>
           <imageobject>
-            <imagedata fileref="figures/welcome.png" format="PNG"
+            <imagedata fileref="figures/welcome.png" 
                    srccredit="Frank H. Ellenberger" />
           </imageobject>
         </mediaobject>
@@ -97,7 +98,7 @@ Translators:
               <title>Soll das Begrüßungsfenster erneut angezeigt werden?</title><screenshot>
                 <mediaobject>
                   <imageobject>
-                    <imagedata fileref="figures/welcome-cancel.png" format="PNG"
+                    <imagedata fileref="figures/welcome-cancel.png" 
                    srccredit="Frank H. Ellenberger" />
                   </imageobject>
                 </mediaobject>
@@ -139,7 +140,7 @@ Translators:
             <title>Minimales &app; Hauptfenster</title><screenshot>
               <mediaobject>
                 <imageobject>
-                  <imagedata fileref="figures/window-main-empty.png" format="PNG"
+                  <imagedata fileref="figures/window-main-empty.png" 
                    srccredit="Frank H. Ellenberger" />
                 </imageobject>
               </mediaobject>
@@ -184,7 +185,7 @@ Translators:
       <title>Der <quote>Tipp des Tages</quote>.</title><screenshot>
         <mediaobject>
           <imageobject>
-            <imagedata fileref="figures/tip-window.png" format="PNG"
+            <imagedata fileref="figures/tip-window.png" 
                    srccredit="Frank H. Ellenberger" />
           </imageobject>
         </mediaobject>
@@ -240,3 +241,4 @@ Translators:
     </para>
   </sect1>
 </chapter>
+

--- a/manual/de/Help_ch_Transactions.xml
+++ b/manual/de/Help_ch_Transactions.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter SYSTEM "gnc-locale-de.dtd">
 <!-- (Do not remove this comment block.)
-Version: 3.5
-Last modified: March 30th 2019
+Version: 4.6
+Last modified: September 2021
+  modified: March 30th 2019
   modified: April 15th 2007
   modified: August 12th 2006
   modified: February 28th 2005
@@ -66,18 +67,21 @@ Translators:
   <sect1 id="trans-win-enter" xreflabel="Buchen Dialog">
     <title>Verwenden des Buchen Dialogs</title>
 
-    <para>Der <guilabel>Buchen</guilabel> Dialog ist im Menü und mit dem Tastenkürzel mittels<menuchoice>
+    <para>Der <guilabel>Buchen</guilabel> Dialog ist im Menü und mit dem Tastenkürzel mittels
+      <menuchoice>
         <shortcut>
         <keycombo>
           <keycap>Strg</keycap><keycap>T</keycap>
         </keycombo>
         </shortcut> <guimenu>A<accel>k</accel>tionen</guimenu>
         <guimenuitem><accel>B</accel>uchen…</guimenuitem>
-      </menuchoice>sowie durch Verwenden der Schaltfläche <guibutton>Buchen</guibutton> in der
+      </menuchoice>
+      sowie durch Verwenden der Schaltfläche <guibutton>Buchen</guibutton> in der
       <emphasis>Werkzeugleiste</emphasis> des Kontobuchs zu erreichen und dient in &app; zwei
-      Zwecken:<itemizedlist spacing="compact">
+      Zwecken:
+      <itemizedlist spacing="compact">
         <listitem>
-          <para>Eine Möglichkeit, einen einfachen (d.h. zweiteilige) Buchung zwischen beliebigen Konten zu
+          <para>Eine Möglichkeit, eine einfache (d.h. zweiteilige) Buchung zwischen beliebigen Konten zu
             erstellen.
           </para>
         </listitem>
@@ -257,7 +261,8 @@ Translators:
 
       <para>Klicken Sie auf <guibutton>OK</guibutton>, um die Buchung durchzuführen (oder den Kurs bzw. Betrag
         zu bestätigen) oder <guibutton>Abbrechen</guibutton>, um den Dialog zu verlassen ohne die
-        Buchung vorzunehmen.<note>
+        Buchung vorzunehmen.
+        <note>
           <para>Beim Abschließen einer Buchung oder Bestätigen eines Wechselkurses wird der Kurs zum Buchungsdatum
             in der <guilabel>Kurs-Datenabank</guilabel> aktualisiert. Siehe
             <xref
@@ -320,7 +325,8 @@ Translators:
 
       <step>
         <para>Bewegen Sie den Cursor mit der <keycap>Tab</keycap>-Taste weiter oder klicken Sie das Feld
-          <guilabel>Nr</guilabel> an. Hier können Sie eine Scheck- bzw. Buchungsnummer eingeben.<tip>
+          <guilabel>Nr</guilabel> an. Hier können Sie eine Scheck- bzw. Buchungsnummer eingeben.
+          <tip>
             <para>Mit der Taste <keycap>+</keycap> wird automatisch die Nummer der letzten Buchung, die eine Nummer
               hatte, um eins erhöht und hier eingefügt.
             </para>
@@ -395,14 +401,18 @@ Translators:
           <quote>ausgeglichen</quote> wird durch Drücken der
           <keycap function="enter">Eingabe</keycap> Taste, Betätigung der
           <guibutton>Eingabe</guibutton> Schaltfläche in der <emphasis> Werkzeugleiste </emphasis>
-          oder mit<menuchoice>
+          oder mit
+          <menuchoice>
             <guimenu>B<accel>u</accel>chung</guimenu><guimenuitem>Buchung
             ein<accel>g</accel>eben</guimenuitem>
-          </menuchoice>die Buchung abgeschlossen. Durch Anklicken der <guibutton>Abbrechen</guibutton> Schaltfläche oder
-          mit<menuchoice>
+          </menuchoice>
+          die Buchung abgeschlossen. Durch Anklicken der <guibutton>Abbrechen</guibutton>
+          Schaltfläche oder mit
+          <menuchoice>
             <guimenu>B<accel>u</accel>chung</guimenu><guimenuitem>Buchung
             <accel>a</accel>bbrechen</guimenuitem>
-          </menuchoice>wird die Buchung gelöscht.
+          </menuchoice>
+          wird die Buchung gelöscht.
         </para>
       </step>
 
@@ -416,14 +426,16 @@ Translators:
       <step>
         <para>Um zu einer leeren Buchung am Ende des Kontobuchs zu wechseln, klicken Sie die
           <guibutton>Neu</guibutton> Schaltfläche in der <emphasis>Werkzeugleiste</emphasis> an
-          oder wählen Sie<menuchoice>
+          oder wählen Sie
+          <menuchoice>
             <shortcut>
             <keycombo>
               <keycap>Strg</keycap><keycap>Bild ab</keycap>
             </keycombo>
             </shortcut> <guimenu>A<accel>k</accel>tionen</guimenu><guimenuitem><accel>L</accel>eere
             Buchung</guimenuitem>
-          </menuchoice>.
+          </menuchoice>
+          .
         </para>
       </step>
     </procedure>
@@ -447,12 +459,12 @@ Translators:
       <title>Der <quote>Buchungsverknüpfung bearbeiten</quote> Dialog</title><screenshot>
         <mediaobject>
           <imageobject role="html">
-            <imagedata fileref="figures/Help_Trans_Assoc_Dialog.png" format="PNG"
-                         srccredit="Christian Wehling" width="510" />
+            <imagedata fileref="figures/Help_Trans_Assoc_Dialog.png" 
+                         srccredit="Christian Wehling" width="&img-w;" />
           </imageobject>
 
           <imageobject role="fo">
-            <imagedata fileref="figures/Help_Trans_Assoc_Dialog.png" format="PNG"
+            <imagedata fileref="figures/Help_Trans_Assoc_Dialog.png" 
                          srccredit="Christian Wehling" />
           </imageobject>
         </mediaobject>
@@ -496,7 +508,7 @@ Translators:
       <title>Kette und Büroklammer</title><screenshot>
         <mediaobject>
           <imageobject>
-            <imagedata fileref="figures/Help_Trans_Assoc_Symbols.png" format="PNG"
+            <imagedata fileref="figures/Help_Trans_Assoc_Symbols.png" 
                        srccredit="Frank H. Ellenberger" />
           </imageobject>
         </mediaobject>
@@ -505,7 +517,8 @@ Translators:
 
     <para>Wird das <guilabel>Kontobuch</guilabel> <guilabel>zweizeilig</guilabel> angezeigt, so befindet sich
       in der zweiten Zeile, also in der Zelle die unterhalb der <guilabel>Abgleichen</guilabel>-
-      Markierung liegt, das Symbol für die <guilabel>Verknüpfung</guilabel> mit<itemizedlist spacing="compact">
+      Markierung liegt, das Symbol für die <guilabel>Verknüpfung</guilabel> mit
+      <itemizedlist spacing="compact">
         <listitem>
           <para>einer <emphasis>Büroklammer</emphasis> wenn zu der Buchung eine Datei zugeordnet ist, oder
           </para>
@@ -515,9 +528,10 @@ Translators:
           <para>einer <emphasis>Kette</emphasis> wenn ein Hyperlink eingetragen ist
           </para>
         </listitem>
-      </itemizedlist>und solange diese Symbole von der aktuellen Schriftart für die Zelle unterstützt werden. Wenn Sie
-      den Mauszeiger über der Zelle platzieren wird der Dateiname oder die URL in einem Tooltip
-      angezeigt und ein Klick darauf öffnet die Datei oder URL genau so wie der Eintrag des
+      </itemizedlist>
+      und solange diese Symbole von der aktuellen Schriftart für die Zelle unterstützt werden.
+      Wenn Sie den Mauszeiger über der Zelle platzieren wird der Dateiname oder die URL in einem
+      Tooltip angezeigt und ein Klick darauf öffnet die Datei oder URL genau so wie der Eintrag des
       Kontextmenüs <guimenuitem>Verknüpfung öffnen</guimenuitem>.
     </para>
   </sect1>
@@ -534,10 +548,12 @@ Translators:
 
     <para>Die weiteren Buchungszeilen werden im einzeiligen Kontobuch nicht angezeigt, es sei denn, die
       Schaltfläche <guibutton>Vollständig</guibutton> in der <emphasis>Werkzeugleiste</emphasis>
-      oder der Menüeintrag<menuchoice>
+      oder der Menüeintrag
+      <menuchoice>
         <guimenu>A<accel>k</accel>tionen</guimenu><guimenuitem><accel>M</accel>ehrteilige
         Buchung</guimenuitem>
-      </menuchoice>sind aktiviert.
+      </menuchoice>
+      sind aktiviert.
     </para>
 
     <procedure>
@@ -625,12 +641,14 @@ Translators:
       <step>
         <para>Um die weiteren Buchungsteile einzugeben, drücken Sie die Schaltfläche
           <guibutton>Vollständig</guibutton> in der <emphasis>Werkzeugleiste</emphasis> oder
-          wählen Sie<menuchoice>
+          wählen Sie
+          <menuchoice>
             <guimenu>A<accel>k</accel>tionen</guimenu><guimenuitem><accel>M</accel>ehrteilige
             Buchung</guimenuitem>
-          </menuchoice>. Buchungen mit mehreren Teilen tragen den Hinweis <emphasis>-- Mehrteilige Buchung --</emphasis>
-          und zur Anzeige der Details wird die Funktion <guibutton>Vollständig</guibutton>
-          benötigt.
+          </menuchoice>
+          . Buchungen mit mehreren Teilen tragen den Hinweis <emphasis>-- Mehrteilige Buchung
+          --</emphasis> und zur Anzeige der Details wird die Funktion
+          <guibutton>Vollständig</guibutton> benötigt.
         </para>
       </step>
 
@@ -667,10 +685,12 @@ Translators:
       <step>
         <para>Bewegen Sie den Cursor zum noch fehlenden Betragsfeld in der dritten Zeile und ergänzen Sie den
           Betrag. Durch Drücken der <keycap function="enter">Eingabe</keycap> Taste, Anklicken der
-          Schaltfläche <guibutton>Eingeben</guibutton> oder mit<menuchoice>
+          Schaltfläche <guibutton>Eingeben</guibutton> oder mit
+          <menuchoice>
             <guimenu>B<accel>u</accel>chung</guimenu><guimenuitem>Buchung
             ein<accel>g</accel>eben</guimenuitem>
-          </menuchoice>wird nunmehr der Cursor zur nächsten Zeile bewegt.
+          </menuchoice>
+          wird nunmehr der Cursor zur nächsten Zeile bewegt.
         </para>
       </step>
 
@@ -693,10 +713,12 @@ Translators:
           sich der Cursor hinter der Leerzeile befindet, so springt der Cursor zum nächsten
           Buchung. Dadurch wird der mehrteilige Vorgang geschlossen; er kann jedoch auch manuell
           geschlossen werden, indem Sie die Schaltfäche <guibutton>Vollständig</guibutton>
-          anklicken oder<menuchoice>
+          anklicken oder
+          <menuchoice>
             <guimenu>A<accel>k</accel>tionen</guimenu><guimenuitem><accel>M</accel>ehrteilige
             Buchung</guimenuitem>
-          </menuchoice>.
+          </menuchoice>
+          .
         </para>
       </step>
     </procedure>
@@ -707,7 +729,8 @@ Translators:
 
     <para>Jede Buchung, deren Teilbuchungen auf unterschiedliche Währungen lauten, erfordert einen
       Wechselkurs, um zwischen den beiden umzurechnen. Weitere Informationen finden Sie in Kapitel
-      10 von <emphasis role="italic">&app; Kurs und Konzepte</emphasis>.<!-- FIXME: How can the "Guide" be linked or where is Chapter 10 in the "Guide"? -->
+      10 von <emphasis role="italic">&app; Kurs und Konzepte</emphasis>.
+<!-- FIXME: How can the "Guide" be linked or where is Chapter 10 in the "Guide"? -->
     </para>
 
     <para>Kontenbücher für Konten des Typs Aktienkonto oder Investmentfonds enthalten die vier Spalten
@@ -745,18 +768,22 @@ Translators:
     <para>Zur Änderung einer Buchung müssen Sie nur den zu ändernden Buchungsteil auswählen. Sobald Sie
       die Änderungen vorgenommen haben, drücken Sie entweder die
       <keycap function="enter">Eingabe</keycap> Taste, betätigen die
-      <guibutton>Eingeben</guibutton> Schaltfläche oder den Menübefehl<menuchoice>
+      <guibutton>Eingeben</guibutton> Schaltfläche oder den Menübefehl
+      <menuchoice>
         <guimenu>B<accel>u</accel>chung</guimenu><guimenuitem>Buchung
         ein<accel>g</accel>eben</guimenuitem>
-      </menuchoice>, und der Cursor springt automatisch zur nächsten Zeile bzw. zur nächsten Buchung.
+      </menuchoice>
+      , und der Cursor springt automatisch zur nächsten Zeile bzw. zur nächsten Buchung.
     </para>
 
     <para>Um für die Bearbeitung eine detailliertere Ansicht die Buchung zu erhalten, betätigen Sie die
       <guibutton>Vollständig</guibutton> Schaltfläche in der <emphasis>Werkzeugleiste</emphasis>
-      oder wählen Sie<menuchoice>
+      oder wählen Sie
+      <menuchoice>
         <guimenu>A<accel>k</accel>tionen</guimenu><guimenuitem><accel>M</accel>ehrteilige
         Buchung</guimenuitem>
-      </menuchoice>.
+      </menuchoice>
+      .
     </para>
   </sect1>
 
@@ -765,25 +792,31 @@ Translators:
 
     <para>Soll eine Buchung aus dem Kontobuch entfernt werden, wählen Sie die Buchung aus und drücken Sie
       entweder die <guibutton>Löschen</guibutton> Schaltfläche in der
-      <emphasis>Werkzeugleiste</emphasis> oder verwendenen Sie<menuchoice>
+      <emphasis>Werkzeugleiste</emphasis> oder verwendenen Sie
+      <menuchoice>
         <guimenu>B<accel>u</accel>chung</guimenu><guimenuitem>Buchung
         <accel>l</accel>öschen</guimenuitem>
-      </menuchoice>. Es öffnet sich ein Dialogfenster, um das Löschen zu bestätigen, sofern die Einstellung nicht
-      geändert wurde. Das Fenster bietet zwei Optionen: <guilabel><accel>A</accel>ntwort speichern
-      und nicht wieder anzeigen.</guilabel> und <guilabel>Antwort speichern und in
+      </menuchoice>
+      . Es öffnet sich ein Dialogfenster, um das Löschen zu bestätigen, sofern die Einstellung
+      nicht geändert wurde. Das Fenster bietet zwei Optionen: <guilabel><accel>A</accel>ntwort
+      speichern und nicht wieder anzeigen.</guilabel> und <guilabel>Antwort speichern und in
       <accel>d</accel>ieser Sitzung nicht wieder anzeigen</guilabel>. Die Antwort wird entsprechend
-      dem ausgewählten Kontrollkästchen gespeichert. Die Voreinstellung kann auch mittels<menuchoice>
+      dem ausgewählten Kontrollkästchen gespeichert. Die Voreinstellung kann auch mittels
+      <menuchoice>
         <guimenu>A<accel>k</accel>tionen</guimenu><guimenuitem><accel>W</accel>arnungen
         zurücksetzen</guimenuitem>
-      </menuchoice>. <xref linkend="reset-warning" /> rückgängig gemacht werden.
+      </menuchoice>
+      . <xref linkend="reset-warning" /> rückgängig gemacht werden.
     </para>
 
     <para>Teile einer Buchung können auch entfernt werden, indem Sie die Schaltfläche
       <guibutton>Vollständig</guibutton> auf der <emphasis>Werkzeugleiste</emphasis> oder durch
-      Auswahl von<menuchoice>
+      Auswahl von
+      <menuchoice>
         <guimenu>A<accel>k</accel>tionen</guimenu><guimenuitem><accel>M</accel>ehrteilige
         Buchung</guimenuitem>
-      </menuchoice>. Die Teilbuchung, die entfernt werden soll, kann dann zum Löschen ausgewählt werden.
+      </menuchoice>
+      . Die Teilbuchung, die entfernt werden soll, kann dann zum Löschen ausgewählt werden.
     </para>
   </sect1>
 
@@ -798,13 +831,15 @@ Translators:
     </para>
 
     <para>Natürlich kann ein Benutzer Stornobuchungen durchaus manuell eingeben; &app; enthält dafür jedoch
-      einen Menüoption (<menuchoice>
+      einen Menüoption (
+      <menuchoice>
         <guimenu>B<accel>u</accel>chungen</guimenu><guimenuitem>Stornobuchung
         <accel>h</accel>inzufügen</guimenuitem>
-      </menuchoice>), der die Stornobuchung schnell für Sie anlegen kann. Diese Option erscheint nur, wenn Sie sich in
-      einem Kontobuch befinden. Wenn Sie eine Buchung ausgewählt haben, die storniert werden soll,
-      brauchen Sie nur diesen Menüpunkt zu wählen, und es wird sofort ein Duplikat der Buchung
-      erstellt, die die aktive Buchung storniert.
+      </menuchoice>
+      ), der die Stornobuchung schnell für Sie anlegen kann. Diese Option erscheint nur, wenn Sie
+      sich in einem Kontobuch befinden. Wenn Sie eine Buchung ausgewählt haben, die storniert
+      werden soll, brauchen Sie nur diesen Menüpunkt zu wählen, und es wird sofort ein Duplikat
+      der Buchung erstellt, die die aktive Buchung storniert.
     </para>
 
     <note>
@@ -828,26 +863,32 @@ Translators:
       <listitem>
         <para>Wenn Sie sich in der <quote>einzeiligen</quote> Ansicht befinden, drücken Sie die Taste
           <guibutton>Vollständig</guibutton> in der <emphasis>Werkzeugleiste</emphasis> oder
-          wählen Sie<menuchoice>
+          wählen Sie
+          <menuchoice>
             <guimenu>A<accel>k</accel>tionen</guimenu><guimenuitem><accel>M</accel>ehrteilige
             Buchung</guimenuitem>
-          </menuchoice>um die Buchung zu öffnen.
+          </menuchoice>
+          um die Buchung zu öffnen.
         </para>
       </listitem>
 
       <listitem>
-        <para>Verwenden Sie<menuchoice>
+        <para>Verwenden Sie
+          <menuchoice>
             <guimenu>B<accel>u</accel>chungen</guimenu><guimenuitem>Andere
             Buchungs<accel>t</accel>eile löschen</guimenuitem>
-          </menuchoice>. Es öffnet sich ein Dialogfenster, um das Löschen zu bestätigen, sofern die Einstellung nicht
-          geändert wurde. Das Fenster bietet zwei Optionen: <guilabel><accel>A</accel>ntwort
-          speichern und nicht wieder anzeigen.</guilabel> und <guilabel>Antwort speichern und in
-          <accel>d</accel>ieser Sitzung nicht wieder anzeigen</guilabel>. Die Antwort wird
-          entsprechend dem ausgewählten Kontrollkästchen gespeichert. Die Voreinstellung kann auch
-          mittels<menuchoice>
+          </menuchoice>
+          . Es öffnet sich ein Dialogfenster, um das Löschen zu bestätigen, sofern die
+          Einstellung nicht geändert wurde. Das Fenster bietet zwei Optionen:
+          <guilabel><accel>A</accel>ntwort speichern und nicht wieder anzeigen.</guilabel> und
+          <guilabel>Antwort speichern und in <accel>d</accel>ieser Sitzung nicht wieder
+          anzeigen</guilabel>. Die Antwort wird entsprechend dem ausgewählten Kontrollkästchen
+          gespeichert. Die Voreinstellung kann auch mittels
+          <menuchoice>
             <guimenu>A<accel>k</accel>tionen</guimenu><guimenuitem><accel>W</accel>arnungen
             zurücksetzen</guimenuitem>
-          </menuchoice>. <xref linkend="reset-warning" /> rückgängig gemacht werden.
+          </menuchoice>
+          . <xref linkend="reset-warning" /> rückgängig gemacht werden.
         </para>
       </listitem>
 
@@ -881,11 +922,14 @@ Translators:
       leeren Zeile für neue Buchungen steht.
     </para>
 
-    <para>Der Menüpunkt<menuchoice>
+    <para>Der Menüpunkt
+      <menuchoice>
         <guimenu>B<accel>u</accel>chung</guimenu><guimenuitem>Buchung
         dupli<accel>z</accel>ieren</guimenuitem>
-      </menuchoice>oder die Schaltfläche <guimenu>Duplizieren</guimenu> in der <emphasis>Werkzeugleiste</emphasis>
-      bietet, im Gegensatz zur Methode Kopieren die Möglichkeit, ein anderes Datum zu wählen.
+      </menuchoice>
+      oder die Schaltfläche <guimenu>Duplizieren</guimenu> in der
+      <emphasis>Werkzeugleiste</emphasis> bietet, im Gegensatz zur Methode Kopieren die
+      Möglichkeit, ein anderes Datum zu wählen.
     </para>
 
     <itemizedlist spacing="compact">
@@ -895,7 +939,8 @@ Translators:
       </listitem>
 
       <listitem>
-        <para>Wählen Sie<menuchoice>
+        <para>Wählen Sie
+          <menuchoice>
             <guimenu>B<accel>u</accel>chung</guimenu><guimenuitem>Buchung
             dupli<accel>z</accel>ieren</guimenuitem>
           </menuchoice>
@@ -965,16 +1010,20 @@ Translators:
         <term><guilabel>u</guilabel></term>
 
         <listitem>
-          <para>Ungültig. Der Status wird manuell mit dem Menüpunkt<menuchoice>
+          <para>Ungültig. Der Status wird manuell mit dem Menüpunkt
+            <menuchoice>
               <guimenu>B<accel>u</accel>chung</guimenu><guimenuitem>Buchung <accel>u</accel>ngültig
               machen</guimenuitem>
-            </menuchoice>(siehe auch <xref linkend="Trans-transaction-menu" />) einer Buchung zugewiesen oder freigegeben und
-            gilt für jede Zeile in der Buchung. Es verbirgt die meisten Buchungsdetails, löscht
-            sie aber nicht. Wird eine Buchung für ungültig erklärt, so ist ein Grund anzugeben,
-            der rechts neben den Buchungsnotizen erscheint. Die Notizen und die Begündung sind nur
-            sichtbar, wenn Sie Folgendes aktiviert haben<menuchoice>
+            </menuchoice>
+            (siehe auch <xref linkend="Trans-transaction-menu" />) einer Buchung zugewiesen oder
+            freigegeben und gilt für jede Zeile in der Buchung. Es verbirgt die meisten
+            Buchungsdetails, löscht sie aber nicht. Wird eine Buchung für ungültig erklärt, so
+            ist ein Grund anzugeben, der rechts neben den Buchungsnotizen erscheint. Die Notizen und
+            die Begündung sind nur sichtbar, wenn Sie Folgendes aktiviert haben
+            <menuchoice>
               <guimenu><accel>A</accel>nsicht</guimenu><guimenuitem><accel>Z</accel>weizeilig</guimenuitem>
-            </menuchoice>.
+            </menuchoice>
+            .
           </para>
         </listitem>
       </varlistentry>
@@ -987,19 +1036,23 @@ Translators:
     <para>Bei der Arbeit im Kontobuch ist es häufig nützlich, ein Konto und gleichzeitig auch das Gegenkonto
       einsehen zu können. Dies ermöglicht &app; ihnen, indem Sie die Schaltfläche
       <guibutton>Springen</guibutton> in der <emphasis>Werkzeugleiste</emphasis> oder den
-      Menübefehl<menuchoice>
+      Menübefehl
+      <menuchoice>
         <guimenu>A<accel>k</accel>tionen</guimenu><guimenuitem>Zum Gegenkonto
         <accel>s</accel>pringen</guimenuitem>
-      </menuchoice>in der Anzeige für das Kontobuch verwenden.
+      </menuchoice>
+      in der Anzeige für das Kontobuch verwenden.
     </para>
 
     <para>Wählen Sie die gewünschte Buchung im Kontobuch betätigen entweder die
-      <guibutton>Springen</guibutton> Schaltfläche oder wählen<menuchoice>
+      <guibutton>Springen</guibutton> Schaltfläche oder wählen
+      <menuchoice>
         <guimenu>A<accel>k</accel>tionen</guimenu><guimenuitem>Zum Gegenkonto
         <accel>s</accel>pringen</guimenuitem>
-      </menuchoice>im Menü um zugehörigen Gegenkonto in einem neuen Fenster zu öffnen. Wenn die Buchung mehr als ein
-      Konto berührt, müssen Sie zuerst alle Buchungsteile anzeigen und das Gegenkonto, zu dem
-      gesprungen werden soll, auswählen
+      </menuchoice>
+      im Menü um zugehörigen Gegenkonto in einem neuen Fenster zu öffnen. Wenn die Buchung mehr
+      als ein Konto berührt, müssen Sie zuerst alle Buchungsteile anzeigen und das Gegenkonto, zu
+      dem gesprungen werden soll, auswählen
     </para>
   </sect1>
 
@@ -1019,9 +1072,12 @@ Translators:
       Buchungssatzes aus dem Kontobuch als Vorlage. Wählen Sie den Buchungssatz, welchen Sie als
       Vorlage verwenden wollen, und anschließend entweder die Schaltfläche
       <guibutton>Terminiert</guibutton> in der <emphasis>Werkzeugleiste</emphasis> oder den
-      Menübefehl<menuchoice>
+      Menübefehl
+      <menuchoice>
         <guimenu>A<accel>k</accel>tionen</guimenu><guimenuitem><accel>T</accel>erminiert…</guimenuitem>
-      </menuchoice>. Anschließend öffnet sich das Dialogfenster <guilabel>Terminierte Buchung erstellen</guilabel>.
+      </menuchoice>
+      . Anschließend öffnet sich das Dialogfenster <guilabel>Terminierte Buchung
+      erstellen</guilabel>.
     </para>
 
     <variablelist spacing="compact">
@@ -1092,11 +1148,13 @@ Translators:
       <title>Übersicht der terminierten Buchungen</title>
 
       <para>Eine Übersicht über die terminierten Buchungen kann aus der <emphasis>Kontenübersicht</emphasis>
-        oder aus dem <emphasis>Kontobuch</emphasis> heraus mit dem Menübefehl<menuchoice>
+        oder aus dem <emphasis>Kontobuch</emphasis> heraus mit dem Menübefehl
+        <menuchoice>
           <guimenu>A<accel>k</accel>tionen</guimenu><guisubmenu>Term<accel>i</accel>nierte
           Buchungen</guisubmenu> <guimenuitem>Terminierte Buchungen
           <accel>E</accel>ditor…</guimenuitem>
-        </menuchoice>geöffnet werden.
+        </menuchoice>
+        geöffnet werden.
       </para>
 
       <para>Die Übersicht für terminerte Buchungen dient dazu, auf eine Liste der geplanten Buchungssätze
@@ -1119,9 +1177,11 @@ Translators:
         Buchungen neu zu erstellen, zu bearbeiten und zu löschen. Die <guibutton>Neu</guibutton>
         und <guibutton>Bearbeiten</guibutton> Schaltflächen öffnen den <guilabel>Terminierte
         Buchungen bearbeiten</guilabel> Assistenten. <guibutton>Löschen</guibutton> entfernt die
-        ausgewählte Buchung. Die gleichen Möglichkeiten bietet das Menü<menuchoice>
+        ausgewählte Buchung. Die gleichen Möglichkeiten bietet das Menü
+        <menuchoice>
           <guimenu><accel>T</accel>erminiert</guimenu><guimenuitem>Neu/Bearbeiten/Löschen</guimenuitem>
-        </menuchoice>.
+        </menuchoice>
+        .
       </para>
 
       <para>Unterhalb der Liste der geplanten Buchungen befindet sich eine Kalenderübersicht mit den
@@ -1426,27 +1486,31 @@ Translators:
     </para>
 
     <para>Um die Funktion zum Drucken eines Schecks in &app; zu benutzen, wählen Sie die Buchung aus, für
-      die Sie einen Scheck bedrucken wollen, und wählen Sie<menuchoice>
+      die Sie einen Scheck bedrucken wollen, und wählen Sie
+      <menuchoice>
         <shortcut>
         <keycombo>
           <keycap>Strg</keycap><keycap>P</keycap>
         </keycombo>
         </shortcut> <guimenu><accel>D</accel>atei</guimenu><guimenuitem>Scheck<accel>s</accel>
         drucken…</guimenuitem>
-      </menuchoice>. Anschließend öffnet sich das Dialogfenster <guilabel>Scheck drucken</guilabel> um die
+      </menuchoice>
+      . Anschließend öffnet sich das Dialogfenster <guilabel>Scheck drucken</guilabel> um die
       ausgewählte Buchung zu drucken.
     </para>
 
     <para>Wollen Sie mehrere Schecks in &app; drucken, führen Sie erst eine Suche aus, um die Buchungen zu
-      finden, die Sie drucken möchten. Mit dem Suchergebniss im aktuellen Fenster gehen Sie zu<menuchoice>
+      finden, die Sie drucken möchten. Mit dem Suchergebniss im aktuellen Fenster gehen Sie zu
+      <menuchoice>
         <shortcut>
         <keycombo>
           <keycap>Strg</keycap><keycap>P</keycap>
         </keycombo>
         </shortcut> <guimenu><accel>D</accel>atei</guimenu><guimenuitem>Scheck<accel>s</accel>
         drucken…</guimenuitem>
-      </menuchoice>. Dadurch wird ebenfalls der Dialog <guilabel>Scheck drucken</guilabel> geöffnet, um alle Buchungen
-      des Suchergebnis zu drucken.
+      </menuchoice>
+      . Dadurch wird ebenfalls der Dialog <guilabel>Scheck drucken</guilabel> geöffnet, um alle
+      Buchungen des Suchergebnis zu drucken.
     </para>
 
     <para>Das Dialogfenster <guilabel>Scheck drucken</guilabel> hat zwei Karteiseiten. Die erste Karteiseite
@@ -1725,9 +1789,11 @@ Translators:
       </note>
 
       <para>Auf die Importfunktionen der vorgenannten Dateiformate, und noch weitere Möglichkeiten zum
-        Importieren anderer Datentypen, kann über das Untermenü<menuchoice>
+        Importieren anderer Datentypen, kann über das Untermenü
+        <menuchoice>
           <guimenu><accel>D</accel>atei</guimenu><guisubmenu><accel>I</accel>mportieren</guisubmenu>
-        </menuchoice>zugegriffen werden.
+        </menuchoice>
+        zugegriffen werden.
       </para>
     </sect2>
 
@@ -1735,10 +1801,12 @@ Translators:
       <title>Import Einstellungen</title>
 <!-- FIXME: source: new register "import" in prefs, adjust link to "prefs-import" -->
       <para>Die Vorgaben für die <link linkend="prefs-online">Import Einstellungen</link>, die der Benutzer im
-        <guilabel>&app; Einstellungen</guilabel> Dialog<menuchoice>
+        <guilabel>&app; Einstellungen</guilabel> Dialog
+        <menuchoice>
           <guimenu><accel>B</accel>earbeiten</guimenu><guisubmenu><accel>E</accel>instellungen</guisubmenu>
-        </menuchoice>festlegen kann, wirken sich auf das Importieren der Buchungen aus den unten beschriebenen Dateien
-        aus.
+        </menuchoice>
+        festlegen kann, wirken sich auf das Importieren der Buchungen aus den unten beschriebenen
+        Dateien aus.
       </para>
     </sect2>
 
@@ -1753,22 +1821,25 @@ Translators:
         Ihres Programms, ob diese Option verfügbar ist.
       </para>
 
-      <para>Wenn Sie QIF-Dateien importieren wollen, wählen Sie<menuchoice>
+      <para>Wenn Sie QIF-Dateien importieren wollen, wählen Sie
+        <menuchoice>
           <guimenu><accel>D</accel>atei</guimenu>
           <guisubmenu><accel>I</accel>mportieren</guisubmenu> <guimenuitem><accel>Q</accel>IF-Datei
           importieren…</guimenuitem>
-        </menuchoice>aus dem Menü, um das unten abgebildete Dialogfeld <quote>QIF-Datei importieren</quote> zu öffnen.
+        </menuchoice>
+        aus dem Menü, um das unten abgebildete Dialogfeld <quote>QIF-Datei importieren</quote> zu
+        öffnen.
       </para>
 
       <figure pgwide="1">
         <title>Der Assistent zum Importieren von QIF-Dateien</title><screenshot id="ImportQIFDruid">
           <mediaobject>
             <imageobject role="html">
-              <imagedata fileref="figures/Help_Import_QIF_Druid.png" format="PNG" srccredit="Christian Wehling" width="510" />
+              <imagedata fileref="figures/Help_Import_QIF_Druid.png"  srccredit="Christian Wehling" width="&img-w;" />
             </imageobject>
 
             <imageobject role="fo">
-              <imagedata fileref="figures/Help_Import_QIF_Druid.png" format="PNG" srccredit="Christian Wehling" />
+              <imagedata fileref="figures/Help_Import_QIF_Druid.png"  srccredit="Christian Wehling" />
             </imageobject>
           </mediaobject>
         </screenshot>
@@ -2028,7 +2099,8 @@ Translators:
               importierten Konten angezeigt werden sollten.
             </para>
 
-            <para>Andere Funktionen sind derzeit nicht verfügbar.<!--FIXME when implemented.-->
+            <para>Andere Funktionen sind derzeit nicht verfügbar.
+<!--FIXME when implemented.-->
             </para>
           </listitem>
         </varlistentry>
@@ -2051,9 +2123,10 @@ Translators:
           <guimenu><accel>D</accel>atei</guimenu>
           <guisubmenu><accel>I</accel>mportieren</guisubmenu> <guimenuitem><accel>O</accel>FX/QFX
           importieren…</guimenuitem>
-        </menuchoice>öffnet einen Dateiauswahldialog. Navigieren Sie zu der Datei, die Sie importieren möchten, wählen
-        Sie eine Datei mit der entsprechenden Erweiterung (.ofx oder .qfx), und drücken Sie dann
-        die <guibutton>Importieren</guibutton> Schaltfläche.
+        </menuchoice>
+        öffnet einen Dateiauswahldialog. Navigieren Sie zu der Datei, die Sie importieren möchten,
+        wählen Sie eine Datei mit der entsprechenden Erweiterung (.ofx oder .qfx), und drücken Sie
+        dann die <guibutton>Importieren</guibutton> Schaltfläche.
       </para>
 
       <para>&app; öffnet dann das Dialogfeld <guilabel>Konto auswählen</guilabel>, um ein Konto aus Ihrer
@@ -2072,22 +2145,24 @@ Translators:
     <sect2 id="trans-import-csv">
       <title>Importieren von CSV Dateien</title>
 
-      <para>Die Auswahl von<menuchoice>
+      <para>Die Auswahl von
+        <menuchoice>
           <guimenu><accel>D</accel>atei</guimenu>
           <guisubmenu><accel>I</accel>mportieren</guisubmenu> <guimenuitem><accel>B</accel>uchungen
           importieren aus CSV…</guimenuitem>
-        </menuchoice>öffnet den unten abgebildete CSV-Buchungsimport Assistenten.
+        </menuchoice>
+        öffnet den unten abgebildete CSV-Buchungsimport Assistenten.
       </para>
 
       <figure pgwide="1">
         <title>Der CSV-Buchungsimport-Assistent - Einführung</title><screenshot id="CSV_Transaction_Import_Assistant">
           <mediaobject>
             <imageobject role="html">
-              <imagedata  fileref="figures/Help_CSV_Transaction_Import_Assistant.png" format="PNG" srccredit="Christian Wehling" width="510px" />
+              <imagedata  fileref="figures/Help_CSV_Transaction_Import_Assistant.png"  srccredit="Christian Wehling" width="&img-w;" />
             </imageobject>
 
             <imageobject role="fo">
-              <imagedata fileref="figures/Help_CSV_Transaction_Import_Assistant.png" format="PNG" srccredit="Christian Wehling" />
+              <imagedata fileref="figures/Help_CSV_Transaction_Import_Assistant.png"  srccredit="Christian Wehling" />
             </imageobject>
           </mediaobject>
         </screenshot>
@@ -2179,11 +2254,11 @@ Translators:
               <title>Der CSV Import Vorschau Bereich</title><screenshot id="CSV_Import_Preview">
                 <mediaobject>
                   <imageobject role="html">
-                    <imagedata  fileref="figures/Help_CSV_Import_transactions_Preview.png" format="PNG" srccredit="Christian Wehling" width="510px" />
+                    <imagedata  fileref="figures/Help_CSV_Import_transactions_Preview.png"  srccredit="Christian Wehling" width="&img-w;" />
                   </imageobject>
 
                   <imageobject role="fo">
-                    <imagedata  fileref="figures/Help_CSV_Import_transactions_Preview.png" format="PNG" srccredit="Christian Wehling" />
+                    <imagedata  fileref="figures/Help_CSV_Import_transactions_Preview.png"  srccredit="Christian Wehling" />
                   </imageobject>
 
                   <caption>
@@ -2218,7 +2293,8 @@ Translators:
 
                   <para>Der Eintrag <guilabel>Wählen Sie das Export-Format</guilabel> aus der Dropdown-Liste definiert eine
                     Konfiguration, die für den Export und Re-Import von &app; Buchungsdaten
-                    verwendet wird.<note>
+                    verwendet wird.
+                    <note>
                       <para>Verwenden Sie diese Einstellung, wenn Sie Daten importieren, die Sie zuvor aus &app; exportiert
                         haben.
                       </para>
@@ -2710,10 +2786,12 @@ Translators:
     <sect2 id="trans-import-MT940-MT942-DTAUS">
       <title>Importieren von MT940 &amp; MT942 SWIFT sowie DTAUS Dateien</title>
 
-      <para>In dem Menü<menuchoice>
+      <para>In dem Menü
+        <menuchoice>
           <guimenu><accel>D</accel>atei</guimenu>
           <guisubmenu><accel>I</accel>mportieren</guisubmenu>
-        </menuchoice>stehen die folgenden Einträge zur Verfügung:
+        </menuchoice>
+        stehen die folgenden Einträge zur Verfügung:
       </para>
 <!--FIXME replace with link to glossary if and when extended to help -->
       <variablelist spacing="compact">
@@ -2772,11 +2850,11 @@ Translators:
         <title>Buchungszuordnung während eines Importvorgangs</title><screenshot id="ImportMatcherScreenShot">
           <mediaobject>
             <imageobject role="html">
-              <imagedata fileref="figures/Help_Import_Transaction_matcher_1.png" format="PNG" srccredit="Christian Wehling" width="510" />
+              <imagedata fileref="figures/Help_Import_Transaction_matcher_1.png"  srccredit="Christian Wehling" width="&img-w;" />
             </imageobject>
 
             <imageobject role="fo">
-              <imagedata fileref="figures/Help_Import_Transaction_matcher_1.png" format="PNG" srccredit="Christian Wehling" />
+              <imagedata fileref="figures/Help_Import_Transaction_matcher_1.png"  srccredit="Christian Wehling" />
             </imageobject>
 
             <caption>
@@ -2805,7 +2883,8 @@ Translators:
         Der <emphasis>Buchungszuordnungsassistent</emphasis> versucht, basierend auf
         Übereinstimmungen von in Listen gespeicherten Schlüsselwörtern zuvor importierter
         Buchungen die den Gegenkonten beim Import zugewiesen wurden, ein passendes Gegenkonto
-        zuzuordnen.<itemizedlist spacing="compact">
+        zuzuordnen.
+        <itemizedlist spacing="compact">
           <listitem>
             <para>Bei einer guten Übereinstimmung wird das Gegenkonto zugewiesen und die Buchung wird als bereit zum
               Importieren gekennzeichnet.
@@ -2824,7 +2903,8 @@ Translators:
       </para>
 
       <para>Der <emphasis>Buchungszuordnungsassistent</emphasis> wird aufgerufen, wenn Buchungsdaten mit einem
-        der folgenden Formaten importiert werden:<itemizedlist spacing="compact">
+        der folgenden Formaten importiert werden:
+        <itemizedlist spacing="compact">
           <listitem>
             <para>QIF
             </para>
@@ -3192,7 +3272,8 @@ Translators:
         </para>
       </note>
 
-      <para>Sie können jederzeit manuell eingreifen, und so<itemizedlist spacing="compact">
+      <para>Sie können jederzeit manuell eingreifen, und so
+        <itemizedlist spacing="compact">
           <listitem>
             <para>die Importaktion ändern, indem Sie ein anderes Kontrollkästchen (oder keines) aktivieren,
             </para>
@@ -3202,18 +3283,21 @@ Translators:
             <para>und/oder manuell ein anderes Gegenkonto zuweisen
             </para>
           </listitem>
-        </itemizedlist>nachdem Sie die zugeordneten Buchungen und Konten sowie die automatisch ausgewählten Aktionen
-        überprüft haben.
+        </itemizedlist>
+        nachdem Sie die zugeordneten Buchungen und Konten sowie die automatisch ausgewählten
+        Aktionen überprüft haben.
       </para>
 
       <para>Die gleichzeitige Auswahl mehrerer Zeilen ist für die Liste der importierten Buchungen möglich.
-        Die folgenden Mausaktionen<footnote>
+        Die folgenden Mausaktionen
+        <footnote>
           <para>Die Maustasten werden neutral mit <emphasis>Button1</emphasis> und <emphasis>Button2</emphasis>
             bezeichnet. Bei vielen Benutzern entspricht <emphasis>Button1</emphasis> der linken und
             <emphasis>Button2</emphasis> der rechten Maustaste. Dies kann durch den Anwender in den
             Einstellungen des Betriebssystems den Bedürfnissen angepasst werden.
           </para>
-        </footnote>können an den Einträgen in der Liste durchgeführt werden:
+        </footnote>
+        können an den Einträgen in der Liste durchgeführt werden:
       </para>
 
       <variablelist spacing="compact">
@@ -3307,25 +3391,31 @@ Translators:
 
       <para>Wenn eine Zeile mit einer bestehenden Buchung übereinstimmt oder eine bestehende Buchung
         aktualisiert werden soll, wird sie mit einem dunkelgrünen Hintergrund dargestellt. Bei ein
-        Doppelklick mit<keycombo action="simul">
+        Doppelklick mit
+        <keycombo action="simul">
           <mousebutton>Button1</mousebutton>
-        </keycombo>auf die Zeile wird der <quote>Buchungszuordnungsassistent</quote> geöffnet, der Details zu den
-        importierten Daten anzeigt. Sollte das falsche Gegenkonto zugewiesen sein oder der
+        </keycombo>
+        auf die Zeile wird der <quote>Buchungszuordnungsassistent</quote> geöffnet, der Details zu
+        den importierten Daten anzeigt. Sollte das falsche Gegenkonto zugewiesen sein oder der
         <quote>Buchungszuordnungsassistent</quote> liefert kein gültiges Ergebnis, können Sie die
         Auswahl des Kontrollkästchens ändern und ein Gegenkonto neu zuordnen (siehe unten).
       </para>
 
-      <para>Ein Doppelklick mit<keycombo action="simul">
+      <para>Ein Doppelklick mit
+        <keycombo action="simul">
           <mousebutton>Button1</mousebutton>
-        </keycombo>auf eine als <guilabel>Neu</guilabel> markierte Zeile mit einem <emphasis>dunkelgrünem</emphasis>
-        Hintergrund und einem zugewiesenen Gegenkonto öffnet den Dialog <guilabel>Konto
-        auswählen</guilabel>, in dem Sie ein zusätzliches Gegenkonto für den zweiten Buchungsteil
-        auswählen können.
+        </keycombo>
+        auf eine als <guilabel>Neu</guilabel> markierte Zeile mit einem
+        <emphasis>dunkelgrünem</emphasis> Hintergrund und einem zugewiesenen Gegenkonto öffnet den
+        Dialog <guilabel>Konto auswählen</guilabel>, in dem Sie ein zusätzliches Gegenkonto für
+        den zweiten Buchungsteil auswählen können.
       </para>
 
-      <para>Wenn Sie stattdessen einen Doppelklick mit<keycombo action="simul">
+      <para>Wenn Sie stattdessen einen Doppelklick mit
+        <keycombo action="simul">
           <mousebutton>Button1</mousebutton>
-        </keycombo>auf einer als <guilabel>Neu</guilabel> markierten Buchung, die den zusätzlichen Kommentar
+        </keycombo>
+        auf einer als <guilabel>Neu</guilabel> markierten Buchung, die den zusätzlichen Kommentar
         <quote>nicht ausgeglichen</quote> enthält und mit einem <phrase>goldenen</phrase>
         Hintergrund versehen ist, ausführen, wird ebenfalls der Kontoauswahldialog geöffent, damit
         Sie der Buchung ein passendes Gegenkonto zuweisen können.
@@ -3334,29 +3424,43 @@ Translators:
       <sect3>
         <title>Ein Gegenkonto einer einzelnen Buchung zuweisen</title>
 
-        <para>Die zu bearbeitende Zeile wird durch einen Mausklick mit<keycombo action="click">
+        <para>Die zu bearbeitende Zeile wird durch einen Mausklick mit
+          <keycombo action="click">
             <mousebutton>Button1</mousebutton>
-          </keycombo>ausgewählt. Darauf hin wird sie mit einer <phrase><?dbhtml bgcolor="#6495ED"?><?dbfo bgcolor="#6495ED"?>kornblumenblauen</phrase> Hintergrundfarbe angezeigt.
+          </keycombo>
+          ausgewählt. Darauf hin wird sie mit einer <phrase>
+<?dbhtml bgcolor="#6495ED"?>
+<?dbfo bgcolor="#6495ED"?>
+          kornblumenblauen</phrase> Hintergrundfarbe angezeigt.
         </para>
 
-        <para>Bei einem doppeltem Mausklick mit<keycombo action="double-click">
+        <para>Bei einem doppeltem Mausklick mit
+          <keycombo action="double-click">
             <mousebutton>Button1</mousebutton>
-          </keycombo>auf eine Zeile wird diese ausgewählt und das Dialogfeld <guilabel>Konto auswählen</guilabel>
-          öffnet sich, in dem Sie ein Gegenkonto zuweisen können. Wählen Sie das gewünschte
-          Konto im Dialog aus und klicken Sie auf <guibutton>OK</guibutton>. Der Dialog hat die
-          Schaltfläche <guibutton>Neues Konto…</guibutton>, mit der Sie ein passendes Konto
-          erstellen können, wenn es kein vorhandenes gibt, das als Gegenkonto verwendet werden
-          kann. Der Hintergrund der Zeile ändert sich zu <phrase><?dbhtml bgcolor="#CFFFCB"?><?dbfo bgcolor="#CFFFCB"?>dunkelgrün</phrase> und das zugewiesene Konto wird in der Spalte <guilabel>zusätzliche
+          </keycombo>
+          auf eine Zeile wird diese ausgewählt und das Dialogfeld <guilabel>Konto
+          auswählen</guilabel> öffnet sich, in dem Sie ein Gegenkonto zuweisen können. Wählen
+          Sie das gewünschte Konto im Dialog aus und klicken Sie auf <guibutton>OK</guibutton>. Der
+          Dialog hat die Schaltfläche <guibutton>Neues Konto…</guibutton>, mit der Sie ein
+          passendes Konto erstellen können, wenn es kein vorhandenes gibt, das als Gegenkonto
+          verwendet werden kann. Der Hintergrund der Zeile ändert sich zu <phrase>
+<?dbhtml bgcolor="#CFFFCB"?>
+<?dbfo bgcolor="#CFFFCB"?>
+          dunkelgrün</phrase> und das zugewiesene Konto wird in der Spalte <guilabel>zusätzliche
           Kommentare</guilabel> angezeigt.
         </para>
 
-        <para>Oder alternativ, ein Mausklick mit<keycombo action="click">
+        <para>Oder alternativ, ein Mausklick mit
+          <keycombo action="click">
             <mousebutton>Button1</mousebutton>
-          </keycombo>auf die Zeile gefolgt von einem Klick mit<keycombo action="click">
+          </keycombo>
+          auf die Zeile gefolgt von einem Klick mit
+          <keycombo action="click">
             <mousebutton>Button2</mousebutton>
-          </keycombo>zeigt das kleine Popup- Fenster <guimenuitem>Gegenkonto zu Auswahl zuweisen</guimenuitem> um den
-          Dialog <guilabel>Konto auswählen</guilabel> zu öffnen, das Gegenkonto auswählen und mit
-          <guibutton>OK</guibutton> bestätigen.
+          </keycombo>
+          zeigt das kleine Popup- Fenster <guimenuitem>Gegenkonto zu Auswahl zuweisen</guimenuitem>
+          um den Dialog <guilabel>Konto auswählen</guilabel> zu öffnen, das Gegenkonto auswählen
+          und mit <guibutton>OK</guibutton> bestätigen.
         </para>
       </sect3>
 
@@ -3368,12 +3472,24 @@ Translators:
           Zielkontos auf alle markierten Buchungen.
         </para>
 
-        <para>Wenn Sie Zeilen in einer Auswahl erfassen, werden sie mit einem <phrase><?dbhtml bgcolor="#6495ED"?><?dbfo bgcolor="#6495ED"?>kornblumenblauem</phrase> Hintergrund markiert.
+        <para>Wenn Sie Zeilen in einer Auswahl erfassen, werden sie mit einem <phrase>
+<?dbhtml bgcolor="#6495ED"?>
+<?dbfo bgcolor="#6495ED"?>
+          kornblumenblauem</phrase> Hintergrund markiert.
         </para>
 
         <para>Nur die Zeilen, in denen das Kontrollkästchen <guilabel>Neu</guilabel> aktiviert ist und die
-          entweder eine <phrase><?dbhtml bgcolor="#CFFFCB"?><?dbfo bgcolor="#CFFFCB"?>dunkelgrüne</phrase> oder <phrase><?dbhtml bgcolor="#FFD700"?><?dbfo bgcolor="#FFD700"?>goldene</phrase> Hintergrundfarbe haben, können in eine Mehrfachauswahl aufgenommen werden. Zeilen
-          mit einem <phrase><?dbhtml bgcolor="#FF4040"?><?dbfo bgcolor="#FF4040"?>braunen</phrase> Hintergrund oder die bei <guilabel>Ü+Abgl</guilabel> oder
+          entweder eine <phrase>
+<?dbhtml bgcolor="#CFFFCB"?>
+<?dbfo bgcolor="#CFFFCB"?>
+          dunkelgrüne</phrase> oder <phrase>
+<?dbhtml bgcolor="#FFD700"?>
+<?dbfo bgcolor="#FFD700"?>
+          goldene</phrase> Hintergrundfarbe haben, können in eine Mehrfachauswahl aufgenommen
+          werden. Zeilen mit einem <phrase>
+<?dbhtml bgcolor="#FF4040"?>
+<?dbfo bgcolor="#FF4040"?>
+          braunen</phrase> Hintergrund oder die bei <guilabel>Ü+Abgl</guilabel> oder
           <guilabel>Abgl</guilabel> angekreuzten sind können nicht in einer Mehrfachauswahl
           markiert werden.
         </para>
@@ -3383,37 +3499,51 @@ Translators:
 
         <itemizedlist spacing="compact">
           <listitem>
-            <para>Klicken Sie mit<keycombo action="click">
+            <para>Klicken Sie mit
+              <keycombo action="click">
                 <mousebutton>Button1</mousebutton>
-              </keycombo>auf die erste Zeile und dann mit<keycombo action='simul'>
+              </keycombo>
+              auf die erste Zeile und dann mit
+              <keycombo action='simul'>
                 <keycap>Strg</keycap> <mousebutton>Button1</mousebutton>
-              </keycombo>auf weitere Zeilen, um die Auswahl zu ergänzen.
+              </keycombo>
+              auf weitere Zeilen, um die Auswahl zu ergänzen.
             </para>
           </listitem>
 
           <listitem>
-            <para>ODer klicken Sie mit<keycombo action="click">
+            <para>ODer klicken Sie mit
+              <keycombo action="click">
                 <mousebutton>Button1</mousebutton>
-              </keycombo>auf die erste Zeile und dann mit<keycombo action='simul'>
+              </keycombo>
+              auf die erste Zeile und dann mit
+              <keycombo action='simul'>
                 <keycap>Umschalt</keycap> <mousebutton>Button1</mousebutton>
-              </keycombo>auf eine andere Zeile, um alle Zeilen dazwischen auszuwählen.
+              </keycombo>
+              auf eine andere Zeile, um alle Zeilen dazwischen auszuwählen.
             </para>
           </listitem>
 
           <listitem>
-            <para>Die Gummibandfunktion ist ebenfalls aktiviert, so dass Sie auch<keycombo action="click">
+            <para>Die Gummibandfunktion ist ebenfalls aktiviert, so dass Sie auch
+              <keycombo action="click">
                 <mousebutton>Button1</mousebutton>
-              </keycombo><emphasis> gedrückt halten und über Zeilen ziehen können</emphasis>, um eine Auswahl zu
-              erstellen. Um weitere Zeilen hinzuzufügen, betätigen Sie<keycombo action="simul">
+              </keycombo>
+              <emphasis> gedrückt halten und über Zeilen ziehen können</emphasis>, um eine
+              Auswahl zu erstellen. Um weitere Zeilen hinzuzufügen, betätigen Sie
+              <keycombo action="simul">
                 <keycap>Strg</keycap><mousebutton>Button1</mousebutton>
-              </keycombo><emphasis>und ziehen</emphasis> Sie über weitere Zeilen.
+              </keycombo>
+              <emphasis>und ziehen</emphasis> Sie über weitere Zeilen.
             </para>
           </listitem>
         </itemizedlist>
 
-        <para>Anschließend klicken Sie mit <emphasis><keycombo action="click">
+        <para>Anschließend klicken Sie mit <emphasis>
+          <keycombo action="click">
             <mousebutton>Button2</mousebutton>
-          </keycombo></emphasis> auf die markierten Zeilen, um ein Popup-Menü anzuzeigen, und wählen Sie dann
+          </keycombo>
+          </emphasis> auf die markierten Zeilen, um ein Popup-Menü anzuzeigen, und wählen Sie dann
           <guimenuitem>Gegenkonto zu Auswahl zuweisen</guimenuitem>, um das Dialogfeld
           <guilabel>Kontoauswahl</guilabel> zu öffnen. Wählen Sie das gewünschte Gegenkonto
           (legen Sie bei Bedarf ein neues Konto an) und klicken Sie auf die Schaltfläche
@@ -3446,20 +3576,22 @@ Translators:
       <para>Mit dem Buchungsauswähler können Sie die automatische Zuordnung einer existierenden &app;-Buchung
         zu einer zu importierenden Buchung überprüfen und bei Bedarf bearbeiten. Wenn Sie im
         <emphasis>Buchungszuordnungsassistent</emphasis> auf eine Buchung, die in der Spalte
-        <guilabel>Abgl</guilabel> markiert ist, einen Doppelklick mit<keycombo action ="double-click">
+        <guilabel>Abgl</guilabel> markiert ist, einen Doppelklick mit
+        <keycombo action ="double-click">
           <mousebutton>Button1</mousebutton>
-        </keycombo>machen, wird der nachfolgende Dialog geöffnet.
+        </keycombo>
+        machen, wird der nachfolgende Dialog geöffnet.
       </para>
 
       <figure pgwide="1">
         <title>Der Buchungsauswähler Dialog</title><screenshot id="ImportMatcherPicker">
           <mediaobject>
             <imageobject role="html">
-              <imagedata fileref="figures/Help_Import_MatchPicker.png" format="PNG" srccredit="Christian Wehling" width="510" />
+              <imagedata fileref="figures/Help_Import_MatchPicker.png"  srccredit="Christian Wehling" width="&img-w;" />
             </imageobject>
 
             <imageobject role="fo">
-              <imagedata fileref="figures/Help_Import_MatchPicker.png" format="PNG" srccredit="Christian Wehling" />
+              <imagedata fileref="figures/Help_Import_MatchPicker.png"  srccredit="Christian Wehling" />
             </imageobject>
 
             <caption>
@@ -3472,7 +3604,8 @@ Translators:
       </figure>
 
       <para>Im oberen Bereich des Buchungsauswähler werden Details zum ersten Teil der zu importierenden
-        Buchung angezeigt. Die Spaltenbezeichnungen:<itemizedlist spacing="compact">
+        Buchung angezeigt. Die Spaltenbezeichnungen:
+        <itemizedlist spacing="compact">
           <listitem>
             <para><guilabel>Konto</guilabel>
             </para>
@@ -3503,9 +3636,12 @@ Translators:
             </para>
           </listitem>
 <!--FIXME ????-->
-        </itemizedlist>sind die gleichen und haben die gleiche Bedeutung wie in der <xref linkend="trans-match-col"/>
-        beschrieben, mit der Ausnahme der Spalte <guilabel>Ausgeglichene Buchung</guilabel>, die den
-        Betrag des Ausgleichenden-Buchungsteils angibt.<!--FIXME not sure what happens here with multisplit transactions -->
+        </itemizedlist>
+        sind die gleichen und haben die gleiche Bedeutung wie in der
+        <xref linkend="trans-match-col"/> beschrieben, mit der Ausnahme der Spalte
+        <guilabel>Ausgeglichene Buchung</guilabel>, die den Betrag des Ausgleichenden-Buchungsteils
+        angibt.
+<!--FIXME not sure what happens here with multisplit transactions -->
       </para>
 
       <para>Der untere Bereich zeigt die Details der vorhandenen &app; Buchungen die mit dieser Buchung
@@ -3582,16 +3718,19 @@ Translators:
           <term><guilabel>Ausstehende Aktion</guilabel></term>
 
           <listitem>
-            <para>???<!--FIXME  not sure what this column really indicates. Doesn't seem to display the actual action proposed i.e. whether it is to skip importing or to update an existing transaction.-->
+            <para>???
+<!--FIXME  not sure what this column really indicates. Doesn't seem to display the actual action proposed i.e. whether it is to skip importing or to update an existing transaction.-->
             </para>
           </listitem>
         </varlistentry>
       </variablelist>
 
       <para>Wenn Sie mit der vorhandenen Buchung, die automatisch abgeglichen wurde, nicht zufrieden sind,
-        klicken Sie mit<keycombo action="click">
+        klicken Sie mit
+        <keycombo action="click">
           <mousebutton>Button1</mousebutton>
-        </keycombo>auf den Eintrag, der zu der importierten Buchung passt, um diese auszuwählen und dann auf
+        </keycombo>
+        auf den Eintrag, der zu der importierten Buchung passt, um diese auszuwählen und dann auf
         <guibutton>OK</guibutton>. Die Buchung wird mit <quote>manuell gewählte Zuordnung</quote>
         in der Spalte <guilabel>zusätzliche Kommentare</guilabel> des
         <guilabel>Buchungszuordnungsassistent</guilabel> gekennzeichnet. Um den Dialog zu verlassen
@@ -3608,21 +3747,23 @@ Translators:
         <guilabel>Buchungszuordnungsassistent</guilabel> zuzuweisen. Damit können Sie die
         <guilabel>Automatisch (Bayesisch)</guilabel>, die <guilabel>Nicht-Bayesische</guilabel> und
         die <guilabel>Online</guilabel> gewonnen Buchungsinformationen bearbeiten. Um den Editor zu
-        öffnen wählen Sie<menuchoice>
+        öffnen wählen Sie
+        <menuchoice>
           <guimenu><accel>W</accel>erkzeuge</guimenu><guimenuitem><accel>I</accel>mport-Zuordnungen
           Editor</guimenuitem>
-        </menuchoice>aus der Menüleiste.
+        </menuchoice>
+        aus der Menüleiste.
       </para>
 
       <figure pgwide="1">
         <title>Der Import-Zuordnungen Editor</title><screenshot>
           <mediaobject>
             <imageobject role="html">
-              <imagedata fileref="figures/Help_Import_Map_Editor.png" format="PNG" srccredit="Christian Wehling" width="510" />
+              <imagedata fileref="figures/Help_Import_Map_Editor.png"  srccredit="Christian Wehling" width="&img-w;" />
             </imageobject>
 
             <imageobject role="fo">
-              <imagedata fileref="figures/Help_Import_Map_Editor.png" format="PNG" srccredit="Christian Wehling" />
+              <imagedata fileref="figures/Help_Import_Map_Editor.png"  srccredit="Christian Wehling" />
             </imageobject>
 
             <caption>
@@ -3809,7 +3950,8 @@ Translators:
       bei dem zwei und mehr Zeilen für Buchungen mit zwei oder mehr Buchungsteilen ausgegeben
       werden, wobei jede Teilinformation in separaten Zeilen geschrieben werden. Buchungsdaten
       können entweder aus dem aktuell aktivem Register oder aus ausgewählten Konten exportiert
-      werden. Die Menübefehle zum Exportieren von Buchungen sind:<itemizedlist spacing="compact">
+      werden. Die Menübefehle zum Exportieren von Buchungen sind:
+      <itemizedlist spacing="compact">
         <listitem>
           <para><menuchoice>
               <guimenu><accel>D</accel>atei</guimenu><guisubmenu>E<accel>x</accel>portieren</guisubmenu><guimenuitem><accel>B</accel>uchungen
@@ -3822,11 +3964,13 @@ Translators:
           <para><menuchoice>
               <guimenu><accel>D</accel>atei</guimenu><guisubmenu>E<accel>x</accel>portieren</guisubmenu><guimenuitem><accel>A</accel>ktives
               Kontobuch als CSV-Datei exportieren…</guimenuitem>
-            </menuchoice>.
+            </menuchoice>
+            .
           </para>
         </listitem>
-      </itemizedlist>Diese Befehle starten den nachfolgend dargestellten Assistenten, um den Export einzurichten. Die
-      beiden Menüpunkte unterscheiden sich nur dadurch, dass im Letzteren der Schritt
+      </itemizedlist>
+      Diese Befehle starten den nachfolgend dargestellten Assistenten, um den Export einzurichten.
+      Die beiden Menüpunkte unterscheiden sich nur dadurch, dass im Letzteren der Schritt
       <guilabel>Kontenauswahl</guilabel> im linken Fensterbereich nicht verfügbar ist.
     </para>
 
@@ -3834,11 +3978,11 @@ Translators:
       <title>Assistent für den Export von Buchungen</title><screenshot id="export-transactions-wizard">
         <mediaobject>
           <imageobject role="html">
-            <imagedata fileref="figures/Help_Choose_Export_Settings.png" format="PNG" srccredit="Christian Wehling" width="510" />
+            <imagedata fileref="figures/Help_Choose_Export_Settings.png"  srccredit="Christian Wehling" width="&img-w;" />
           </imageobject>
 
           <imageobject role="fo">
-            <imagedata fileref="figures/Help_Choose_Export_Settings.png" format="PNG" srccredit="Christian Wehling" />
+            <imagedata fileref="figures/Help_Choose_Export_Settings.png"  srccredit="Christian Wehling" />
           </imageobject>
         </mediaobject>
       </screenshot>
@@ -4145,9 +4289,11 @@ Translators:
             </varlistentry>
           </variablelist>
 
-          <para>Wenn Sie Ihre Einstellungen vorgenommen haben, geht es mit<keycombo action="click">
+          <para>Wenn Sie Ihre Einstellungen vorgenommen haben, geht es mit
+            <keycombo action="click">
               <mousebutton>Button1</mousebutton>
-            </keycombo>auf <guibutton>Weiter</guibutton> zum nächsten Schritt im Assistenten weiter.
+            </keycombo>
+            auf <guibutton>Weiter</guibutton> zum nächsten Schritt im Assistenten weiter.
           </para>
         </listitem>
       </varlistentry>
@@ -4161,14 +4307,19 @@ Translators:
           </para>
 
           <para>Das Bedienfeld <guilabel>Konten</guilabel> zeigt eine Kontenstruktur an, in der ein oder mehrere
-            Konten für den Export ausgewählt werden können. (<keycombo action="click">
+            Konten für den Export ausgewählt werden können. (
+            <keycombo action="click">
               <keycap>Strg</keycap><mousebutton>Button1</mousebutton>
-            </keycombo>und<keycombo action="click">
+            </keycombo>
+            und
+            <keycombo action="click">
               <keycap>Shift</keycap><mousebutton>Button1</mousebutton>
-            </keycombo>können verwendet werden, um Konten auszuwählen). Die Schaltfläche <guibutton>Unterkonten
-            auswählen</guibutton> wählt alle Unterkonten eines markierten Kontos aus. Die
-            Schaltfläche <guibutton>Alle auswählen</guibutton> wählt alle Konten in der
-            Kontenstruktur für den Export aus. Die Anzahl der ausgewählten Konten wird angezeigt.
+            </keycombo>
+            können verwendet werden, um Konten auszuwählen). Die Schaltfläche
+            <guibutton>Unterkonten auswählen</guibutton> wählt alle Unterkonten eines markierten
+            Kontos aus. Die Schaltfläche <guibutton>Alle auswählen</guibutton> wählt alle Konten
+            in der Kontenstruktur für den Export aus. Die Anzahl der ausgewählten Konten wird
+            angezeigt.
           </para>
 
           <para>Im <guilabel>Datumsbereich</guilabel> können Sie angeben, ob entweder alle Buchungen oder nur die
@@ -4193,9 +4344,11 @@ Translators:
 
         <listitem>
           <para>Der Dateiname und Pfad der zu exportierenden Datei und die Anzahl der zu exportierenden Konten wird
-            angezeigt. Um den Export fortzusetzen betätigen Sie<keycombo action="click">
+            angezeigt. Um den Export fortzusetzen betätigen Sie
+            <keycombo action="click">
               <mousebutton>Button1</mousebutton>
-            </keycombo>die <guibutton>Anwenden</guibutton> Schaltfläche.
+            </keycombo>
+            die <guibutton>Anwenden</guibutton> Schaltfläche.
           </para>
         </listitem>
       </varlistentry>
@@ -4246,11 +4399,13 @@ Translators:
         <term>Saldenabfrage…</term>
 
         <listitem>
-          <para>Mit<menuchoice>
+          <para>Mit
+            <menuchoice>
               <guimenu>A<accel>k</accel>tion</guimenu><guimenuitem><accel>O</accel>nline
               Aktion</guimenuitem><guisubmenu><accel>S</accel>aldenabfrage…</guisubmenu>
-            </menuchoice>wird für das ausgewählte Konto eine Onlineverbindung zu dem Geldinstitut aufgebaut und der
-            aktuelle Kontosaldo abgefragt. Nach kurzer Zeit wird Ihnen, im sich öffnendem
+            </menuchoice>
+            wird für das ausgewählte Konto eine Onlineverbindung zu dem Geldinstitut aufgebaut und
+            der aktuelle Kontosaldo abgefragt. Nach kurzer Zeit wird Ihnen, im sich öffnendem
             Dialogfenster, der Saldo angezeigt und Sie können direkt im Anschluss das
             <xref linkend="acct-reconcile" />.
           </para>
@@ -4261,13 +4416,15 @@ Translators:
         <term>Abfrage Kontoumsätze…</term>
 
         <listitem>
-          <para>Der Menüpunkt<menuchoice>
+          <para>Der Menüpunkt
+            <menuchoice>
               <guimenu>A<accel>k</accel>tion</guimenu><guimenuitem><accel>O</accel>nline
               Aktion</guimenuitem><guisubmenu>Abfrage Konto<accel>u</accel>msätze…</guisubmenu>
-            </menuchoice>bietet Ihnen die Möglichkeit, die Umsätze des in der Kontenstruktur markierten Onlinekontos, oder
-            des geöffenten Kontobuchs, abzurufen und im Anschluss in &app; zu importieren. Es wird
-            der Dialog <guilabel>Online Kontoumsätze abfragen</guilabel> angezeigt, in dem Sie den
-            Zeitraum für die Umsatzabfrage näher angeben können.
+            </menuchoice>
+            bietet Ihnen die Möglichkeit, die Umsätze des in der Kontenstruktur markierten
+            Onlinekontos, oder des geöffenten Kontobuchs, abzurufen und im Anschluss in &app; zu
+            importieren. Es wird der Dialog <guilabel>Online Kontoumsätze abfragen</guilabel>
+            angezeigt, in dem Sie den Zeitraum für die Umsatzabfrage näher angeben können.
           </para>
 
           <variablelist spacing="compact">
@@ -4353,10 +4510,13 @@ Translators:
         <term>SEPA Einzelüberweisung…</term>
 
         <listitem>
-          <para>Wenn Sie im Menü den Eintrag<menuchoice>
+          <para>Wenn Sie im Menü den Eintrag
+            <menuchoice>
               <guimenu>A<accel>k</accel>tion</guimenu><guimenuitem><accel>O</accel>nline
               Aktion</guimenuitem><guisubmenu>SEPA <accel>E</accel>inzelüberweisung…</guisubmenu>
-            </menuchoice>wählen, öffnet sich der Dialog<variablelist spacing="compact">
+            </menuchoice>
+            wählen, öffnet sich der Dialog
+            <variablelist spacing="compact">
               <title>Online-Auftrag Einzelüberweisung</title>
 
               <varlistentry>
@@ -4433,7 +4593,8 @@ Translators:
                     Eingaben als Überweisungvorlage zur Wiederverwendung zu speichern und
                     gespeicherten Vorlagen per Doppelklick auf einen Eintrag abzurufen. Die
                     gespeicherten Angaben werden dann in die Felder der oberen Fensterhälfte als
-                    eine neue Einzelüberweisung eingetragen.<variablelist spacing="compact">
+                    eine neue Einzelüberweisung eingetragen.
+                    <variablelist spacing="compact">
                       <varlistentry>
                         <term>Listenfeld der <guilabel>Vorlagen</guilabel></term>
 
@@ -4493,12 +4654,14 @@ Translators:
                   </para>
                 </listitem>
               </varlistentry>
-            </variablelist>Sind die Pflichtfelder des Überweisungsauftrags ausgefüllt wird die Schaltfläche <guilabel>Jetzt
-            ausführen</guilabel> aktiviert. Darauf hin öffnet sich der, mit den Überweisungsdaten
-            vorausgefüllte, <xref linkend="trans-win-enter" /> und Sie haben die Möglichkeit die
-            Daten für den Überweisungsauftrag zu kontrollieren. Wenn Sie den Dialog mit
-            <guilabel>OK</guilabel> bestätigen, wird ein Onlineauftrag an Ihre Geldinstitut
-            gesendet.<note>
+            </variablelist>
+            Sind die Pflichtfelder des Überweisungsauftrags ausgefüllt wird die Schaltfläche
+            <guilabel>Jetzt ausführen</guilabel> aktiviert. Darauf hin öffnet sich der, mit den
+            Überweisungsdaten vorausgefüllte, <xref linkend="trans-win-enter" /> und Sie haben die
+            Möglichkeit die Daten für den Überweisungsauftrag zu kontrollieren. Wenn Sie den
+            Dialog mit <guilabel>OK</guilabel> bestätigen, wird ein Onlineauftrag an Ihre
+            Geldinstitut gesendet.
+            <note>
               <para>Wenn Sie die Schaltfläche <guibutton>Abbrechen</guibutton> betätigen wird der Dialog für die
                 Einzelüberweisung geschlossen, der Online-Auftrag nicht ausgeführt und eine zuvor
                 neu angelegte Überweiungsvorlage nicht gespeichert.
@@ -4512,11 +4675,13 @@ Translators:
         <term>Interne Umbuchung…</term>
 <!-- FIXME: Insert a description for this item. -->
         <listitem>
-          <para>Die Funktion<menuchoice>
+          <para>Die Funktion
+            <menuchoice>
               <guimenu>A<accel>k</accel>tion</guimenu><guimenuitem><accel>O</accel>nline
               Aktion</guimenuitem><guisubmenu> <accel>I</accel>nterne Umbuchung…</guisubmenu>
-            </menuchoice>kann der Übersetzer nicht ausprobieren, weil das Geldinstitut diesen Geschäftsvorfall für seine
-            Konten nicht unterstützen.
+            </menuchoice>
+            kann der Übersetzer nicht ausprobieren, weil das Geldinstitut diesen Geschäftsvorfall
+            für seine Konten nicht unterstützen.
           </para>
         </listitem>
       </varlistentry>
@@ -4537,10 +4702,12 @@ Translators:
     </para>
 
     <para>Standardmäßig werden im Journal nur die Buchungen des letzten Monats angezeigt. Sie können mit
-      dem Menüpunkt<menuchoice>
+      dem Menüpunkt
+      <menuchoice>
         <guimenu><accel>A</accel>nsicht</guimenu><guimenuitem><accel>F</accel>ilter
         nach…</guimenuitem>
-      </menuchoice>den Datumsbereich eingrenzen.
+      </menuchoice>
+      den Datumsbereich eingrenzen.
     </para>
   </sect1>
 </chapter>


### PR DESCRIPTION
* Entfernen der überflüssigen Angabe des Bildformates (png),
* Die Breite der Bilder mit der Entität "&img-w;" anstelle von "510px"
justiert.

Betrifft:
* ch_GettingStarted
* ch_Transactions