### PR TITLE
L10N:de: Entfernen von spacing="compact" aus allen *list-Elementen

### DIFF
--- a/manual/de/Help_ch_Account-Actions.xml
+++ b/manual/de/Help_ch_Account-Actions.xml
@@ -183,7 +183,8 @@
                   <para><warning>
                       <para>Die Kontenarten Verbindlichkeiten und Forderungen werden zur Verwaltung offener Rechnungen, auch
                         <quote>offene Posten</quote> genannt, verwendet. Buchungen, die diese Konten
-                        betreffen, sollten ausschließlich durch Verwendung von<itemizedlist spacing="compact">
+                        betreffen, sollten ausschließlich durch Verwendung von
+                        <itemizedlist>
                           <listitem>
                             <para>einbuchen/ausbuchen von Lieferantenrechnung/Rechnung/Auslagenerstattung oder
                             </para>
@@ -591,7 +592,7 @@
       </screenshot>
     </figure>
 
-    <variablelist spacing="compact">
+    <variablelist>
       <title>Dialogführung</title>
 
       <para>Die Schaltflächen in dem Assistenten werden erst dann sichtbar bzw. aktiviert, wenn Sie die
@@ -780,7 +781,7 @@
           Ein einfacher Klick wird verwendet, um ein Konto zu markieren.
         </para>
 
-        <variablelist spacing="compact">
+        <variablelist>
           <title>Die Spaltenüberschriften der Tabelle</title>
 
           <para>Sie können einige Einträge für die Konten ändern, indem Sie den entsprechenden Eintrag in der
@@ -905,7 +906,7 @@
       Dialogfenster <guilabel>Neues Konto</guilabel> benötigt werden.
     </para>
 
-    <itemizedlist spacing="compact">
+    <itemizedlist>
       <listitem>
         <para>Welche Kontoart wird benötigt?
         </para>
@@ -959,7 +960,7 @@
         Eingabefelder zur Verfügung.
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Kontobezeichnung</guilabel></term>
 
@@ -998,7 +999,7 @@
               </para>
             </note>
 
-            <itemizedlist spacing="compact">
+            <itemizedlist>
               <listitem>
                 <para>Für die meisten Konten wird hier die Standardwährung, d.h. Ihre Landeswährung, z.B. <quote>EUR
                   (Euro)</quote> angezeigt. Falls das Konto für eine Fremdwährung vorgesehen ist,
@@ -1181,7 +1182,7 @@
         </note>
       </para>
     </sect2>
-<!-- FIXME: this is to be inserted after the move to a new chapter -->
+
     <sect2 id="accts-online-quotes">
       <title>Verwenden der Online-Kursaktualisierung</title>
 
@@ -1214,9 +1215,9 @@
         </listitem>
 
         <listitem>
-          <para>Legen Sie das Wertpapier an. Verwenden Sie entweder den<menuchoice>
+          <para>Legen Sie das Wertpapier an. Verwenden Sie entweder den <menuchoice>
               <guimenu><accel>W</accel>erkzeug</guimenu><guimenuitem><accel>W</accel>ertpaper-Editor</guimenuitem>
-            </menuchoice>für bestehende Aktien/Fonds oder, wie oben beschrieben, den <guilabel>Neue
+            </menuchoice> für bestehende Aktien/Fonds oder, wie oben beschrieben, den <guilabel>Neue
             Wertpapier/Währung</guilabel> Dialog für eine neue Aktie/Fonds.
           </para>
 
@@ -1394,7 +1395,7 @@ and update the appendix. -->
         Informationen</guilabel>.
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Saldo</guilabel></term>
 
@@ -1417,7 +1418,7 @@ and update the appendix. -->
       <para>Der nächste Bereich betrifft den <guilabel>Buchung Anfangssaldo</guilabel>.
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Benutze Eigenkapitalkonto</guilabel></term>
 
@@ -1812,7 +1813,7 @@ and update the appendix. -->
       Optionen, die Sie bei dem Vorgehen zum Löschen der der Daten unterstützt.
     </para>
 
-    <variablelist spacing="compact">
+    <variablelist>
       <varlistentry>
         <term><guilabel>Unterkonten</guilabel></term>
 
@@ -1820,7 +1821,7 @@ and update the appendix. -->
           <para>Dem ausgewählten Konto ist ein Unterkonto zugeordnet.
           </para>
 
-          <variablelist spacing="compact">
+          <variablelist>
             <varlistentry>
               <term><guilabel>Unterkonto löschen</guilabel></term>
 
@@ -1851,7 +1852,7 @@ and update the appendix. -->
           <para>Das zu löschende Konto enthält noch Buchungen.
           </para>
 
-          <variablelist spacing="compact">
+          <variablelist>
             <varlistentry>
               <term><guilabel>Alle Buchungen löschen</guilabel></term>
 
@@ -1882,7 +1883,7 @@ and update the appendix. -->
           <para>Das Unterkonto, das Sie löschen möchten, enthält noch Buchungen.
           </para>
 
-          <variablelist spacing="compact">
+          <variablelist>
             <varlistentry>
               <term><guilabel>Alle Buchungen löschen</guilabel></term>
 
@@ -2061,7 +2062,7 @@ and update the appendix. -->
         </para>
       </tip>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Datum</guilabel></term>
 
@@ -2134,7 +2135,7 @@ and update the appendix. -->
       <para>Der Saldobereich zeigt eine Zusammenfassung der Salden, die für den Abgleich verwendet werden.
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Datum des Kontoauszugs</guilabel></term>
 
@@ -2244,7 +2245,9 @@ and update the appendix. -->
           <xref linkend="trans-import-qif" />. Im Zuge diese Importvorgangs werden ebenfalls Konten
           in Ihre &app;-Datendatei importiert.
         </para>
-      </note><itemizedlist spacing="compact">
+      </note>
+
+      <itemizedlist>
         <para>Falls das Konto bereits existiert, werden diese vier Felder aktualisiert:
         </para>
 
@@ -2417,7 +2420,7 @@ and update the appendix. -->
               <xref linkend="gen-info"/> erklärt.
             </para>
 
-            <orderedlist spacing="compact">
+            <orderedlist>
               <listitem>
                 <para><guilabel>Kontoart</guilabel>
                 </para>
@@ -2513,7 +2516,7 @@ and update the appendix. -->
   <sect1 id="acct-export">
     <title>Exportieren von Konten</title>
 
-    <itemizedlist spacing="compact">
+    <itemizedlist>
       <para>Wenn Sie den Bedarf haben, Ihre &app;-Konten zu exportieren, so haben Sie hierzu die Auswahl
         zwischen zwei unterschiedlichen Exportformaten:
       </para>
@@ -2596,7 +2599,7 @@ and update the appendix. -->
         </tgroup>
       </table>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>XML</guilabel></term>
 

--- a/manual/de/Help_ch_Customize.xml
+++ b/manual/de/Help_ch_Customize.xml
@@ -116,7 +116,7 @@ Translators:
         <xref linkend ="Common-summary-bar" />.
       </simpara>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Anfangsdatum</guilabel></term>
 
@@ -124,7 +124,7 @@ Translators:
             <para>Dieser Eintrag legt das Startdatum der Abrechnungsperiode fest.
             </para>
 
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Relativ</guilabel></term>
 
@@ -161,7 +161,7 @@ Translators:
             <para>Diese Position legt das Enddatum der Buchhaltungsperiode fest.
             </para>
 
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Relativ</guilabel></term>
 
@@ -188,7 +188,7 @@ Translators:
           <term><guilabel>Inhalt Zusammenfassungsleiste</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <title></title>
 
               <varlistentry>
@@ -246,7 +246,7 @@ Translators:
         beeinflussen.
       </simpara>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Trennzeichen</guilabel></term>
 
@@ -270,7 +270,7 @@ Translators:
               Informationen zu diesen Kontotypen.
             </para>
 
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Keine</guilabel></term>
 
@@ -326,7 +326,7 @@ Translators:
             <para>Dieser Punkt legt fest, welche Währung standardmäßig beim Anlegen neuer Konten ausgewählt wird.
             </para>
 
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Systemeinstellung</guilabel></term>
 
@@ -364,7 +364,7 @@ Translators:
               eingestellt wird.
             </para>
 
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Kontofarbe als Hintergrund anzeigen</guilabel></term>
 
@@ -415,12 +415,12 @@ Translators:
       <simpara>Mit den Optionen auf diesem Reiter legen Sie Einstellung für den Umgang mit Rechnungen fest.
       </simpara>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Allgemein</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Zusätzliche Werkzeugleisten-Knöpfe</guilabel></term>
 
@@ -469,7 +469,7 @@ Translators:
               die Lieferantenrechnung (Rechnungseingang).
             </para>
 
-            <variablelist spacing="compact">
+            <variablelist>
 <!--  FIXME source: new item -->
               <varlistentry>
                 <term><guilabel>Bei Fälligkeit benachrichtigen</guilabel></term>
@@ -583,12 +583,12 @@ Translators:
         festzulegen.
       </simpara>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Zahlen</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
 <!-- FIXME source: new item -->
               <varlistentry>
                 <term><guilabel>Kurse immer als Dezimalzahlen anzeigen</guilabel></term>
@@ -642,7 +642,7 @@ Translators:
         </varlistentry>
       </variablelist>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Datumsformat</guilabel></term>
 
@@ -651,7 +651,7 @@ Translators:
               der Auswahlmöglichkeiten). Die verfügbaren Auswahlmöglichkeiten sind:
             </para>
 
-            <itemizedlist spacing="compact">
+            <itemizedlist>
               <listitem>
                 <para>USA
                 </para>
@@ -687,7 +687,7 @@ Translators:
             <para>Mit dieser Option können Sie den Umstand verwalten, dass ein Datum ohne Jahreszahl eingegeben wird.
             </para>
 
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Im atuellen Kalenderjahr</guilabel></term>
 
@@ -713,12 +713,12 @@ Translators:
         </varlistentry>
       </variablelist>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Zeit</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>24-Stunden-Format</guilabel></term>
 
@@ -768,12 +768,12 @@ Translators:
         &app;-Datendatei, Logdateien sowie verknüpften Dokumenten betreffen.
       </simpara>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Allgemein</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>"Tipp des Tages" anzeigen</guilabel></term>
 
@@ -859,7 +859,7 @@ Translators:
               </para>
             </note>
 
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Datei komprimieren</guilabel></term>
 
@@ -928,7 +928,7 @@ Translators:
                     </para>
                   </tip>
 
-                  <variablelist spacing="compact">
+                  <variablelist>
                     <varlistentry>
                       <term><guilabel>Nie</guilabel></term>
 
@@ -969,7 +969,7 @@ Translators:
           <term><guilabel>Verknüpfte Dateien</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Anfang des Dateipfads für verknüpfte Dokumente (relativer Pfad)</guilabel></term>
 
@@ -1002,7 +1002,7 @@ Translators:
           <term><guilabel>Such-Dialog</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Ergebnisanzahl für Neue Suche</guilabel></term>
 
@@ -1047,12 +1047,12 @@ Translators:
         beschrieben.
       </simpara>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Allgemein</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>"Überspringen"-Aktion aktivieren</guilabel></term>
 
@@ -1183,7 +1183,7 @@ Translators:
           <term><guilabel>QIF Import</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Erklärungsseiten anzeigen</guilabel></term>
 
@@ -1206,7 +1206,7 @@ Translators:
                     bereitgestellten Schaltflächen festlegen:
                   </para>
 
-                  <itemizedlist spacing="compact">
+                  <itemizedlist>
                     <listitem>
                       <para><guilabel>Unbestätigt</guilabel> (Standardvorgabe)
                       </para>
@@ -1259,12 +1259,12 @@ Translators:
         Programmm neu zu bauen und die Option WITH_AQBANKING zu aktivieren.
       </simpara>
 <!-- FIXME source: move QIF-Import to new Import-Section -->
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Onlinebanking</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Fenster nach Verbindungsende schließen</guilabel></term>
 
@@ -1347,7 +1347,7 @@ Translators:
         Online-Kursen mit dem &app-perl;-Modul &app-fq; beeinflussen.
       </simpara>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Alpha Vantage API key</guilabel></term>
 
@@ -1359,6 +1359,7 @@ Translators:
                 <para>Die Kursaktualisierung mit &app-fq; wird in <xref linkend="finance-quote" /> beschrieben.
                 </para>
               </tip>
+
               <tip>
                 <para>Im Anhang werden gängige <xref linkend="fq-sources"/> aufgelistet.
                 </para>
@@ -1396,12 +1397,12 @@ Translators:
       <simpara>Dieser Bereich enthält die Optionen zur Anpassung für die Druckausgabe.
       </simpara>
 <!-- FIXME: move appendixd.xml (Auxiliary File Formats) from Guide into Help, insert xref -->
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Scheckformulare drucken</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Datumsformat zusätzlich drucken</guilabel></term>
 
@@ -1464,12 +1465,12 @@ Translators:
       <simpara>In diesem Bereich wird die Arbeit mit Buchungen sowie deren Darstellung beeinflusst.
       </simpara>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Aktionen</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Mit Eingabe gehen Sie zur leeren Buchung</guilabel></term>
 
@@ -1534,7 +1535,7 @@ Translators:
           <term><guilabel>Kontenabgleich</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Bestätigte Buchungen automatisch abgleichen</guilabel></term>
 
@@ -1588,7 +1589,7 @@ Translators:
               <ulink url="&url-wiki;GTK3#Register_Appearance" ></ulink> beschrieben.
             </para>
 
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Benutze die &appname;-eigenen Farben</guilabel></term>
 
@@ -1633,7 +1634,7 @@ Translators:
                 <term><guilabel>Layout</guilabel></term>
 
                 <listitem>
-                  <variablelist spacing="compact">
+                  <variablelist>
                     <varlistentry>
                       <term>Zukünftige Transaktionen nach leerer Buchung</term>
 
@@ -1683,12 +1684,12 @@ Translators:
         Einstellungen wirken sich erst bei dem <emphasis>Öffnen</emphasis> eines Kontobuchs aus.
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Voreinstellung Buchungsansicht</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Einzeilig</guilabel></term>
 
@@ -1726,7 +1727,7 @@ Translators:
           <term><guilabel>Andere Voreinstellungen</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Kontobuch in neuem Fenster öffnen</guilabel></term>
 
@@ -1810,12 +1811,12 @@ Scrolling to older transactions is not possible. If you want to see all entries 
       <para>Die Einstellungen auf diesem Reiter beeinflussen das Verhalten von &app;- Berichten.
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Standardwährung für Berichte</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Systemeinstellung</guilabel></term>
 
@@ -1841,7 +1842,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
           <term><guilabel>Position</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Bericht in neuem Fenster öffnen</guilabel></term>
 
@@ -1859,7 +1860,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
           <term><guilabel>Voreinstellung Vergrößerung</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Voreingestellte Vergrößerung</guilabel></term>
 
@@ -1905,12 +1906,12 @@ Scrolling to older transactions is not possible. If you want to see all entries 
         finden sich in <xref linkend="trans-sched"/>.
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Seit-letztem-Aufruf Fenster</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <note>
                 <para>Weitere Information hinsichtlich des Dialog <guilabel>Seit letzem Aufruf</guilabel> finden Sie unter
                   <xref linkend="trans-sched-slr" />
@@ -1957,7 +1958,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
           <term><guilabel>Voreinstellungen Buchungseditor</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Neue Buchungen automatisch erstellen</guilabel></term>
 
@@ -2023,12 +2024,12 @@ Scrolling to older transactions is not possible. If you want to see all entries 
         konfigurieren.
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Fenster-Einstellungen</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Fenstergrößen und -positionen speichern</guilabel></term>
 
@@ -2053,7 +2054,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
           <term><guilabel>Karteikarten-Ansicht</guilabel></term>
 
           <listitem>
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Den Knopf "Schließen" bei Karteikarten-Ansicht anzeigen</guilabel></term>
 
@@ -2208,7 +2209,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
         Buchhaltungsfunktion des Kontobuchs beeinflussen.
       </para>
 <!-- FIXME source: change sect3 into variablelist -->
-      <variablelist spacing="compact" >
+      <variablelist  >
         <varlistentry id="trading-accounts-book-option">
           <term><guilabel>Devisenhandel-Konten benutzen</guilabel></term>
 
@@ -2277,7 +2278,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
             </para>
 
             <warning>
-              <variablelist spacing="compact">
+              <variablelist>
                 <varlistentry>
                   <term>Die Ersteinrichtung von &app;</term>
 
@@ -2302,7 +2303,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
             </warning>
 
             <tip>
-              <variablelist spacing="compact">
+              <variablelist>
                 <varlistentry>
                   <term>Umstieg von Quicken</term>
 
@@ -2319,7 +2320,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
             </tip>
 
             <warning>
-              <variablelist spacing="compact">
+              <variablelist>
                 <varlistentry>
                   <term>Ändern dieser Option für eine vorhandene &app; Datei</term>
 
@@ -2430,7 +2431,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
         es sich gut machen, z.B. als <quote>Firmenname</quote> seinen Namen einzusetzen:
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Firmenname</guilabel></term>
 
@@ -2552,7 +2553,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
         <glossterm linkend="gl-gui-acct-tree-col">Kontenspalten</glossterm> angezeigt werden.
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Nummer</guilabel></term>
 
@@ -2642,7 +2643,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
         <guimenuitem>Stil<accel>v</accel>orlagen</guimenuitem>
       </menuchoice>
       . Es stehen diese Vorlagen zur Verfügung:
-      <itemizedlist spacing="compact">
+      <itemizedlist>
         <listitem>
           <para><guilabel>Voreinstellung</guilabel>, als Standardvorgabe
           </para>
@@ -2695,7 +2696,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
         </tip>
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <title>Dialogführung</title>
 
         <varlistentry>
@@ -2795,12 +2796,12 @@ Scrolling to older transactions is not possible. If you want to see all entries 
           <guilabel>Allgemein</guilabel> und <guilabel>Tabellen</guilabel>.
         </para>
 
-        <variablelist spacing="compact">
+        <variablelist>
           <varlistentry>
             <term>Der Reiter <guilabel>Farben</guilabel></term>
 
             <listitem>
-              <variablelist spacing="compact" id="style-def-color" xreflabel="Der Reiter Farben">
+              <variablelist  id="style-def-color" xreflabel="Der Reiter Farben">
                 <varlistentry>
                   <term><guilabel>Zweite Farbe für Tabellenzeile</guilabel></term>
 
@@ -2818,7 +2819,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
             <term>Der Reiter <guilabel>Schriftarten</guilabel></term>
 
             <listitem>
-              <variablelist spacing="compact" id="style-def-fonts" xreflabel="Der Reiter Schriftarten">
+              <variablelist  id="style-def-fonts" xreflabel="Der Reiter Schriftarten">
                 <varlistentry>
                   <term><guilabel>Titel</guilabel></term>
 
@@ -2907,7 +2908,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
             <term>Der Reiter <guilabel>Allgemein</guilabel></term>
 
             <listitem>
-              <variablelist spacing="compact" id="style-def-general" xreflabel="Der Reiter Allgemein">
+              <variablelist  id="style-def-general" xreflabel="Der Reiter Allgemein">
                 <varlistentry>
                   <term><guilabel>Hintergrundfarbe</guilabel></term>
 
@@ -2945,7 +2946,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
             <term>Der Reiter <guilabel>Tabellen</guilabel></term>
 
             <listitem>
-              <variablelist spacing="compact" id="style-def-tables" xreflabel="Der Reiter Tabellen">
+              <variablelist  id="style-def-tables" xreflabel="Der Reiter Tabellen">
                 <varlistentry>
                   <term><guilabel>Zellen-Abstand</guilabel></term>
 
@@ -2987,12 +2988,12 @@ Scrolling to older transactions is not possible. If you want to see all entries 
           <guilabel>Tabellen</guilabel>.
         </para>
 
-        <variablelist spacing="compact">
+        <variablelist>
           <varlistentry>
             <term>Der Reiter <guilabel>Farben</guilabel></term>
 
             <listitem>
-              <variablelist spacing="compact" id="style-easy-colors" xreflabel="Der Reiter Farben">
+              <variablelist  id="style-easy-colors" xreflabel="Der Reiter Farben">
                 <varlistentry>
                   <term><guilabel>Hintergrund</guilabel></term>
 
@@ -3085,7 +3086,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
             <term>Der Reiter <guilabel>Allgemein</guilabel></term>
 
             <listitem>
-              <variablelist spacing="compact" id="style-easy-general" xreflabel="Der Reiter Allgmein">
+              <variablelist  id="style-easy-general" xreflabel="Der Reiter Allgmein">
                 <varlistentry>
                   <term><guilabel>Sachbearbeiter</guilabel></term>
 
@@ -3138,7 +3139,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
             <term>Der Reiter <guilabel>Bilder</guilabel></term>
 
             <listitem>
-              <variablelist spacing="compact" id="style-easy-images" xreflabel="Der Reiter Bilder">
+              <variablelist  id="style-easy-images" xreflabel="Der Reiter Bilder">
                 <varlistentry>
                   <term><guilabel>Hintergrundkachel</guilabel></term>
 
@@ -3206,7 +3207,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
           <guilabel>Bilder</guilabel> und <guilabel>Tabellen</guilabel>.
         </para>
 
-        <variablelist spacing="compact">
+        <variablelist>
           <varlistentry>
             <term>Der Reiter <guilabel>Farben</guilabel></term>
 
@@ -3231,7 +3232,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
             <term>Der Reiter <guilabel>Allgemein</guilabel></term>
 
             <listitem>
-              <variablelist spacing="compact" id="style-head-trail-general" xreflabel="Der Reiter Allgmein">
+              <variablelist  id="style-head-trail-general" xreflabel="Der Reiter Allgmein">
                 <varlistentry>
                   <term><guilabel>Sachbearbeiter</guilabel></term>
 
@@ -3449,7 +3450,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
           <guimenu>Edit</guimenu> <guimenuitem>Tax Report Options</guimenuitem>
         </menuchoice>
         :
-        <itemizedlist spacing="compact">
+        <itemizedlist>
           <listitem>
             <para>Tax-related but has no tax code
             </para>
@@ -3512,7 +3513,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
       <guibutton>Edit</guibutton> to set the identity. The Tax Name is optional. If entered, it will
       be printed at the top of the report. A <guilabel>Type</guilabel> must be selected in order to
       activate the tax category selections. The choices are:
-      <itemizedlist spacing="compact">
+      <itemizedlist>
         <listitem>
           <para>Individual, Joint, etc. - Files US Form 1040 Tax Return
           </para>
@@ -3785,7 +3786,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
     <para>Warnungen können selektiv aktiviert werden, wobei der Dialog in zwei Rubriken aufgeteilt ist.
     </para>
 
-    <para><variablelist spacing="compact">
+    <para><variablelist>
         <varlistentry>
           <term><guilabel>Dauerhafte Warnung</guilabel></term>
 
@@ -3825,7 +3826,7 @@ Scrolling to older transactions is not possible. If you want to see all entries 
       </para>
     </tip>
 
-    <variablelist spacing="compact">
+    <variablelist>
       <varlistentry>
         <term>&lin;</term>
 
@@ -3851,9 +3852,9 @@ Scrolling to older transactions is not possible. If you want to see all entries 
             Beispiel: Starten Sie &app; mit diesem Befehl
             <command>LANGUAGE=<replaceable>tr</replaceable>
             LANG=<replaceable>de_DE.utf8</replaceable> gnucash</command> so wird das Programm in
-            türkischer Sprache arbeiten, Sie haben jedoch die Möglichkeit z.B. eine
-            deutsche Steuererklärung vorzubereiten.
-            <!-- ToDo: in C entsprechend LANGUAGE=<replaceable>es</replaceable> und US-TXF
+            türkischer Sprache arbeiten, Sie haben jedoch die Möglichkeit z.B. eine deutsche
+            Steuererklärung vorzubereiten.
+<!-- ToDo: in C entsprechend LANGUAGE=<replaceable>es</replaceable> und US-TXF
             und Anregung für Übersetzter, die größe sprachliche Minorität zu wählen -->
           </para>
         </listitem>

--- a/manual/de/Help_ch_GUIMenus.xml
+++ b/manual/de/Help_ch_GUIMenus.xml
@@ -207,7 +207,7 @@
       <para>Die Kontenübersicht zeigt Ihren gegenwärtigen Kontenplan in einer Baumstruktur an. Dies
         ermöglicht, dass Sie Ihre Konten nach Kontenarten organisieren können. Dies eröffnet
         Ihnen diese Möglichkeiten:
-        <itemizedlist spacing="compact">
+        <itemizedlist>
           <listitem>
             <para>Überblick bedeutet Vergleich von Basiskennzahlen wie etwa aktueller Saldo ohne Berichte starten zu
               müssen.
@@ -298,7 +298,7 @@
         Konten an und sind in <xref linkend="acct-create" /> beschrieben. Daneben stehen weitere
         Spalten zur Anzeige von dynamischen Inhalten zur Verfügung. Diese gibt es in zwei
         unterschiedliche Ausprägungen.
-        <orderedlist spacing="compact">
+        <orderedlist>
           <listitem>
             <para>Kontowährung —ohne Klammern– als nominelle Darstellung.
             </para>
@@ -482,7 +482,7 @@
       <para>Die Abbildungen zeigen die Grundeinstellung zur Filterung der Kontoarten
       </para>
 
-      <variablelist spacing="compact" id="gl-gui-acct-filter">
+      <variablelist  id="gl-gui-acct-filter">
         <varlistentry>
           <term><guilabel>Kontoart</guilabel></term>
 
@@ -492,7 +492,7 @@
               <xref linkend="TypeAccounts" /> beschrieben, rechts Knöpfe zur Vorauswahl:
             </para>
 
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Alle auswählen</guilabel></term>
 
@@ -532,7 +532,7 @@
               auszuwählen.
             </para>
 
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Versteckte Konten anzeigen</guilabel></term>
 

--- a/manual/de/Help_ch_GettingHelp.xml
+++ b/manual/de/Help_ch_GettingHelp.xml
@@ -119,7 +119,7 @@
     <para>Das komplette Hilfemenü wird in <xref linkend="AccTree-help-menu"></xref>beschrieben.
     </para>
 
-    <variablelist spacing="compact">
+    <variablelist>
       <title>Betriebssystem und Hilfeanzeigeprogramm</title>
 
       <para>Abhängig von Ihrem Betriebssystem werden unterschiedliche Programme verwendet, um dieses
@@ -209,7 +209,7 @@
       <title>&app; Website</title>
 
       <para>Die mehrsprachige <ulink url="&url-www;">&app; Website</ulink> enthält:
-        <variablelist spacing="compact">
+        <variablelist>
           <varlistentry>
             <term>Ankündigungen</term>
 
@@ -259,7 +259,7 @@
       <para>Für den Fall, dass Sie eher eine andere Form bevorzugen, gibt es <emphasis>3rd party
         services</emphasis>, die einige der, meist englisch sprachigen, Listen in andere Formate
         konvertieren:
-        <variablelist spacing="compact">
+        <variablelist>
           <varlistentry>
             <term>Web Forum</term>
 

--- a/manual/de/Help_ch_GettingStarted.xml
+++ b/manual/de/Help_ch_GettingStarted.xml
@@ -46,7 +46,7 @@ Translators:
       können. Er enthält die folgenden Steuerungselemente:
     </para>
 
-    <variablelist id="CreateAccounts" spacing="compact">
+    <variablelist id="CreateAccounts" >
       <varlistentry>
         <term><guibutton><accel>N</accel>eue Konten erstellen</guibutton></term>
 
@@ -106,7 +106,7 @@ Translators:
             </figure>
           </para>
 
-          <variablelist spacing="compact">
+          <variablelist>
             <varlistentry>
               <term><guibutton>Nein</guibutton></term>
 

--- a/manual/de/Help_ch_Transactions.xml
+++ b/manual/de/Help_ch_Transactions.xml
@@ -43,7 +43,7 @@ Translators:
   <para>&app; kennt mehrere Methoden zur Eingabe von Buchungen.
   </para>
 
-  <itemizedlist spacing="compact">
+  <itemizedlist>
     <listitem>
       <para>Der gängigste Weg ist die direkte Eingabe in das Kontobuch.
       </para>
@@ -79,7 +79,7 @@ Translators:
       sowie durch Verwenden der Schaltfläche <guibutton>Buchen</guibutton> in der
       <emphasis>Werkzeugleiste</emphasis> des Kontobuchs zu erreichen und dient in &app; zwei
       Zwecken:
-      <itemizedlist spacing="compact">
+      <itemizedlist>
         <listitem>
           <para>Eine Möglichkeit, eine einfache (d.h. zweiteilige) Buchung zwischen beliebigen Konten zu
             erstellen.
@@ -110,7 +110,7 @@ Translators:
         <guilabel>Buchungstext</guilabel> sind optional.
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Betrag</guilabel></term>
 
@@ -173,7 +173,7 @@ Translators:
         entsprechenden Ansicht.
       </para>
 
-      <itemizedlist spacing="compact">
+      <itemizedlist>
         <listitem>
           <para>Wählen Sie das <guilabel>Herkunftskonto</guilabel>.
           </para>
@@ -217,7 +217,7 @@ Translators:
         </para>
       </tip>
 
-      <itemizedlist spacing="compact">
+      <itemizedlist>
         <listitem>
           <para>Wählen Sie das Optionsfeld <guilabel>Wechselkurs</guilabel>, wenn Sie einen Kurs eingeben wollen,
             oder verwenden Sie die Schaltfläche <guilabel>Wechselkurs abrufen</guilabel>.
@@ -518,7 +518,7 @@ Translators:
     <para>Wird das <guilabel>Kontobuch</guilabel> <guilabel>zweizeilig</guilabel> angezeigt, so befindet sich
       in der zweiten Zeile, also in der Zelle die unterhalb der <guilabel>Abgleichen</guilabel>-
       Markierung liegt, das Symbol für die <guilabel>Verknüpfung</guilabel> mit
-      <itemizedlist spacing="compact">
+      <itemizedlist>
         <listitem>
           <para>einer <emphasis>Büroklammer</emphasis> wenn zu der Buchung eine Datei zugeordnet ist, oder
           </para>
@@ -859,7 +859,7 @@ Translators:
       Jedoch wird so die Wirkung besser erkennbar.)
     </para>
 
-    <orderedlist spacing="compact">
+    <orderedlist>
       <listitem>
         <para>Wenn Sie sich in der <quote>einzeiligen</quote> Ansicht befinden, drücken Sie die Taste
           <guibutton>Vollständig</guibutton> in der <emphasis>Werkzeugleiste</emphasis> oder
@@ -932,7 +932,7 @@ Translators:
       Möglichkeit, ein anderes Datum zu wählen.
     </para>
 
-    <itemizedlist spacing="compact">
+    <itemizedlist>
       <listitem>
         <para>Wählen Sie den zu duplizierenden Geschäftsvorgang aus.
         </para>
@@ -967,7 +967,7 @@ Translators:
       zeigt den Status einer Buchung an. Mögliche Werte sind:
     </para>
 
-    <variablelist spacing="compact">
+    <variablelist>
       <varlistentry>
         <term><guilabel>n</guilabel></term>
 
@@ -1080,7 +1080,7 @@ Translators:
       erstellen</guilabel>.
     </para>
 
-    <variablelist spacing="compact">
+    <variablelist>
       <varlistentry>
         <term><guilabel>Name</guilabel></term>
 
@@ -1218,7 +1218,7 @@ Translators:
       <para>Nachfolgend werden die Funktionen auf den drei Register näher beschrieben.
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Übersicht</guilabel></term>
 
@@ -1227,7 +1227,7 @@ Translators:
               und das <guilabel>Auftreten</guilabel> für die terminierte Buchung zu konfigurieren.
             </para>
 
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Optionen</guilabel></term>
 
@@ -1236,7 +1236,7 @@ Translators:
                     terminierten Buchungen steuern.
                   </para>
 
-                  <variablelist spacing="compact">
+                  <variablelist>
                     <varlistentry>
                       <term><guilabel>Aktiv</guilabel></term>
 
@@ -1296,7 +1296,7 @@ Translators:
                   <para>Hier werden die Wiederholungen für die terminierte Buchungen eingestellt.
                   </para>
 
-                  <variablelist spacing="compact">
+                  <variablelist>
                     <varlistentry>
                       <term><guilabel>Immer</guilabel></term>
 
@@ -1345,7 +1345,7 @@ Translators:
               zeitlichen Abstand zueinander die Buchungen ausgeführt werden.
             </para>
 
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Häufigkeit</guilabel></term>
 
@@ -1355,7 +1355,7 @@ Translators:
                     Beginn der terminierten Buchungen festgelegt.
                   </para>
 
-                  <variablelist spacing="compact">
+                  <variablelist>
                     <varlistentry>
                       <term><guilabel>Keine</guilabel></term>
 
@@ -1447,7 +1447,7 @@ Translators:
               Kontobuch eingetragen.
             </para>
 
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Menüleiste</guilabel> und <guilabel>Werkzeugleiste</guilabel></term>
 
@@ -1525,7 +1525,7 @@ Translators:
       US-Letter</quote>.
     </para>
 
-    <variablelist spacing="compact">
+    <variablelist>
       <varlistentry>
         <term><guilabel>Scheckformat</guilabel></term>
 
@@ -1592,7 +1592,7 @@ Translators:
       wird nach rechts größer und y = 0 am oberen Rand des Schecks und nimmt nach unten hin zu.
     </para>
 
-    <itemizedlist spacing="compact">
+    <itemizedlist>
       <listitem>
         <para><guilabel>Zahlungsempfänger</guilabel>
         </para>
@@ -1648,7 +1648,7 @@ Translators:
       Schecks auf der Seite.
     </para>
 
-    <variablelist spacing="compact">
+    <variablelist>
       <varlistentry>
         <term><guilabel>Verschiebung</guilabel></term>
 
@@ -1725,7 +1725,7 @@ Translators:
         Tabellenkalkulationen verwendet wird.
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><link linkend="trans-import-qif">QIF</link></term>
 
@@ -1845,7 +1845,7 @@ Translators:
         </screenshot>
       </figure>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <title>Dialogführung</title>
 
         <para>In jedem Fenster kommen diese Navigationsschaltflächen zur Anwendung:
@@ -1885,7 +1885,7 @@ Translators:
         </para>
       </note>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <title>Schritte des Importdialogs</title>
 
         <para>Im linken Fensterbereich ist der Fortschritt des Importvorgangs aufgelistet. Das rechte Fenster
@@ -2172,7 +2172,7 @@ Translators:
         Informationsfenster die die Funktionalität beschreiben.
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <title>Dialogführung</title>
 
         <para>In jedem Fenster kommen diese Navigationsschaltflächen zur Anwendung:
@@ -2212,7 +2212,7 @@ Translators:
         </para>
       </note>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <title>Schritte des CSV-Importprozesses</title>
 
         <para>Im linken Fensterbereich ist der Fortschritt des Importvorgangs aufgelistet. Erläuternder Text und
@@ -2269,7 +2269,7 @@ Translators:
               </screenshot>
             </figure>
 
-            <variablelist spacing="compact">
+            <variablelist>
               <title>Importvorschau Steuerelemente</title>
 
               <varlistentry>
@@ -2321,7 +2321,7 @@ Translators:
                 <listitem>
                   <para></para>
 
-                  <variablelist spacing="compact">
+                  <variablelist>
                     <varlistentry>
                       <term><guilabel>Trennzeichen</guilabel></term>
 
@@ -2379,7 +2379,7 @@ Translators:
                     enthalten.
                   </para>
 
-                  <variablelist spacing="compact">
+                  <variablelist>
                     <varlistentry>
                       <term><guilabel>Zeichenkodierung</guilabel></term>
 
@@ -2449,7 +2449,7 @@ Translators:
               folgenden Informationen angegeben werden:
             </para>
 
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Datum</guilabel></term>
 
@@ -2492,7 +2492,7 @@ Translators:
               werden können, enthält Folgendes:
             </para>
 
-            <variablelist spacing="compact">
+            <variablelist>
               <varlistentry>
                 <term><guilabel>Keine</guilabel></term>
 
@@ -2794,7 +2794,7 @@ Translators:
         stehen die folgenden Einträge zur Verfügung:
       </para>
 <!--FIXME replace with link to glossary if and when extended to help -->
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guimenuitem><accel>M</accel>T940 importieren</guimenuitem></term>
 
@@ -2884,7 +2884,7 @@ Translators:
         Übereinstimmungen von in Listen gespeicherten Schlüsselwörtern zuvor importierter
         Buchungen die den Gegenkonten beim Import zugewiesen wurden, ein passendes Gegenkonto
         zuzuordnen.
-        <itemizedlist spacing="compact">
+        <itemizedlist>
           <listitem>
             <para>Bei einer guten Übereinstimmung wird das Gegenkonto zugewiesen und die Buchung wird als bereit zum
               Importieren gekennzeichnet.
@@ -2904,7 +2904,7 @@ Translators:
 
       <para>Der <emphasis>Buchungszuordnungsassistent</emphasis> wird aufgerufen, wenn Buchungsdaten mit einem
         der folgenden Formaten importiert werden:
-        <itemizedlist spacing="compact">
+        <itemizedlist>
           <listitem>
             <para>QIF
             </para>
@@ -2945,7 +2945,7 @@ Translators:
       <para>Das Fenster verfügt über die folgenden Elemente:
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <title>Steurungselemente</title>
 
         <varlistentry>
@@ -3020,7 +3020,7 @@ Translators:
         für jede der einzelnen Buchungen die folgenden Informationen anzeigen.
       </para>
 
-      <variablelist spacing="compact" id="trans-match-col">
+      <variablelist  id="trans-match-col">
         <title>Liste der importierten Buchungen</title>
 
         <varlistentry>
@@ -3273,7 +3273,7 @@ Translators:
       </note>
 
       <para>Sie können jederzeit manuell eingreifen, und so
-        <itemizedlist spacing="compact">
+        <itemizedlist>
           <listitem>
             <para>die Importaktion ändern, indem Sie ein anderes Kontrollkästchen (oder keines) aktivieren,
             </para>
@@ -3300,7 +3300,7 @@ Translators:
         können an den Einträgen in der Liste durchgeführt werden:
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><keycombo action="simul">
               <mousebutton>Button1</mousebutton>
@@ -3497,7 +3497,7 @@ Translators:
         <para>So wählen Sie Zeilen aus und fügen Zeilen zu einer Auswahl hinzu:
         </para>
 
-        <itemizedlist spacing="compact">
+        <itemizedlist>
           <listitem>
             <para>Klicken Sie mit
               <keycombo action="click">
@@ -3605,7 +3605,7 @@ Translators:
 
       <para>Im oberen Bereich des Buchungsauswähler werden Details zum ersten Teil der zu importierenden
         Buchung angezeigt. Die Spaltenbezeichnungen:
-        <itemizedlist spacing="compact">
+        <itemizedlist>
           <listitem>
             <para><guilabel>Konto</guilabel>
             </para>
@@ -3653,7 +3653,7 @@ Translators:
         Fensterbereich sind:
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <varlistentry>
           <term><guilabel>Genauigkeit</guilabel></term>
 
@@ -3778,7 +3778,7 @@ Translators:
         bearbeitet werden:
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <title>Steuerungselemente</title>
 
         <varlistentry>
@@ -3818,7 +3818,7 @@ Translators:
         </varlistentry>
       </variablelist>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <title>Die Informationen des Bayesischen-Algorithmus</title>
 
         <varlistentry>
@@ -3882,7 +3882,7 @@ Translators:
         <guilabel>Nicht-Bayesische</guilabel> Abgleicher.
       </para>
 
-      <variablelist spacing="compact">
+      <variablelist>
         <title>Steuerelemente im unteren Bereich</title>
 
         <varlistentry>
@@ -3951,7 +3951,7 @@ Translators:
       werden, wobei jede Teilinformation in separaten Zeilen geschrieben werden. Buchungsdaten
       können entweder aus dem aktuell aktivem Register oder aus ausgewählten Konten exportiert
       werden. Die Menübefehle zum Exportieren von Buchungen sind:
-      <itemizedlist spacing="compact">
+      <itemizedlist>
         <listitem>
           <para><menuchoice>
               <guimenu><accel>D</accel>atei</guimenu><guisubmenu>E<accel>x</accel>portieren</guisubmenu><guimenuitem><accel>B</accel>uchungen
@@ -3995,7 +3995,7 @@ Translators:
     <para>In jedem Fenster kommen diese Navigationsschaltflächen zur Anwendung:
     </para>
 
-    <variablelist spacing="compact">
+    <variablelist>
       <title>Dialogführung</title>
 
       <varlistentry>
@@ -4032,7 +4032,7 @@ Translators:
       </para>
     </note>
 
-    <variablelist spacing="compact">
+    <variablelist>
       <title>Schritte des Exportdialogs</title>
 
       <varlistentry id="trans-export-settings">
@@ -4043,7 +4043,7 @@ Translators:
             Buchungen wählen.
           </para>
 
-          <variablelist spacing="compact">
+          <variablelist>
             <varlistentry>
               <term><guilabel>Optionen</guilabel></term>
 
@@ -4051,7 +4051,7 @@ Translators:
                 <para>Die beiden Kontrollkästchen können einzeln oder zusammen ausgewählt werden:
                 </para>
 
-                <variablelist spacing="compact">
+                <variablelist>
                   <varlistentry>
                     <term><guilabel>Anführungszeichen verwenden</guilabel></term>
 
@@ -4071,7 +4071,7 @@ Translators:
                         einen einzeiligen Export der Buchungen sind:
                       </para>
 
-                      <orderedlist spacing="compact">
+                      <orderedlist>
                         <listitem>
                           <para><guilabel>Datum</guilabel>
                           </para>
@@ -4129,14 +4129,14 @@ Translators:
                         einen mehrzeiligen Export der Buchungen sind:
                       </para>
 
-                      <variablelist spacing="compact">
+                      <variablelist>
                         <varlistentry>
                           <term>Daten nur in der ersten Zeile</term>
 
                           <listitem>
                             <para></para>
 
-                            <orderedlist spacing="compact" continuation="restarts">
+                            <orderedlist  continuation="restarts">
                               <listitem>
                                 <para><guilabel>Datum</guilabel>
                                 </para>
@@ -4181,7 +4181,7 @@ Translators:
                           <listitem>
                             <para></para>
 
-                            <orderedlist spacing="compact" continuation="continues">
+                            <orderedlist  continuation="continues">
                               <listitem>
                                 <para><guilabel>Aktion</guilabel>
                                 </para>
@@ -4248,7 +4248,7 @@ Translators:
                 <para>Diese Optionsfelder erlauben die Auswahl eines alternativen Spaltentrenners:
                 </para>
 
-                <variablelist spacing="compact">
+                <variablelist>
                   <varlistentry>
                     <term><guilabel>Komma (,)</guilabel></term>
 
@@ -4392,7 +4392,7 @@ Translators:
       </para>
     </tip>
 
-    <variablelist spacing="compact">
+    <variablelist>
       <title></title>
 
       <varlistentry>
@@ -4427,7 +4427,7 @@ Translators:
             angezeigt, in dem Sie den Zeitraum für die Umsatzabfrage näher angeben können.
           </para>
 
-          <variablelist spacing="compact">
+          <variablelist>
             <title>Datumsbereich der abzurufenden Buchungen</title>
 
             <varlistentry>
@@ -4436,7 +4436,7 @@ Translators:
               <listitem>
                 <para></para>
 
-                <variablelist spacing="compact">
+                <variablelist>
                   <varlistentry>
                     <term><guilabel>Frühest mögliches Datum</guilabel></term>
 
@@ -4475,7 +4475,7 @@ Translators:
               <listitem>
                 <para></para>
 
-                <variablelist spacing="compact">
+                <variablelist>
                   <varlistentry>
                     <term><guilabel>Jetzt</guilabel></term>
 
@@ -4516,7 +4516,7 @@ Translators:
               Aktion</guimenuitem><guisubmenu>SEPA <accel>E</accel>inzelüberweisung…</guisubmenu>
             </menuchoice>
             wählen, öffnet sich der Dialog
-            <variablelist spacing="compact">
+            <variablelist>
               <title>Online-Auftrag Einzelüberweisung</title>
 
               <varlistentry>
@@ -4594,7 +4594,7 @@ Translators:
                     gespeicherten Vorlagen per Doppelklick auf einen Eintrag abzurufen. Die
                     gespeicherten Angaben werden dann in die Felder der oberen Fensterhälfte als
                     eine neue Einzelüberweisung eingetragen.
-                    <variablelist spacing="compact">
+                    <variablelist>
                       <varlistentry>
                         <term>Listenfeld der <guilabel>Vorlagen</guilabel></term>
 

--- a/manual/de/Help_para-assist-intro.xml
+++ b/manual/de/Help_para-assist-intro.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter SYSTEM "gnc-locale-de.dtd">
-<variablelist spacing="compact">
+<variablelist>
   <title>Dialogführung</title>
 
   <para>Im linken Fensterbereich sind die einzelnen Schritte des Assistenten aufgelistet. Erläuternder Text


### PR DESCRIPTION
Wird in einem späteren commit pauschal für alle Listen-Typen in der xsl-Definition gesetzt.

* ch_Account-Actions
* ch_Customize
* ch_GettingHelp
* ch_GettingStarted
* ch_GUIMenus
* ch_Transactions
* para-assist-intro