### PR TITLE
Removed the information of HACKING file from README.

### DIFF
--- a/README
+++ b/README
@@ -69,7 +69,6 @@ can help. PLEASE let us know via IRC or the gnucash-devel mailing list what
 you can work on or help with.
 
 See also:
-* HACKING 
 * http://wiki.gnucash.org/wiki/Documentation_Update_Instructions
 * http://wiki.gnucash.org/wiki/Translation
 


### PR DESCRIPTION
@fellen told me I had made a mistake to remove the information of HACKING from README
 in https://github.com/Gnucash/gnucash-docs/pull/229#discussion_r719927329.

This PR removes HACKING information from the README file.