### PR TITLE
Expand description of what the Find Transactions dialog searches.

### DIFF
--- a/manual/C/Help_ch_Tools_Assistants.xml
+++ b/manual/C/Help_ch_Tools_Assistants.xml
@@ -55,12 +55,12 @@
       <title>Find Transaction</title>
 
       <para><guilabel>Find Transaction</guilabel> is used to search for transactions in &app; and display the
-        results in a register window. To open the <guilabel>Find Transaction</guilabel> dialog in
-        <guilabel>Split Search</guilabel> mode, you can type the keyboard shortcut
+        results in a <link linkend="general-journal">General Journal</link> type tab. To open the <guilabel>Find Transaction</guilabel> dialog in
+        you can type the keyboard shortcut
         <keycombo>
           <keycap>Ctrl</keycap><keycap>F</keycap>
         </keycombo>
-        .
+        or from the main menu use<menuchoice><guimenu>Edit</guimenu><guimenuitem>Find...</guimenuitem></menuchoice>. 
       </para>
 
       <para>

--- a/manual/C/Help_ch_Tools_Assistants.xml
+++ b/manual/C/Help_ch_Tools_Assistants.xml
@@ -64,14 +64,28 @@
       </para>
 
       <para>
-        Exactly which transactions are searched depends on where you invoke the tool from. If you start from
-        the main accounts hierarchy page, all transactions will be searched. If you start from an
-        individual account register, only transactions in that account will be searched. And if you
-        filter the transactions in a register using
-        <menuchoice>
-          <guimenuitem>View </guimenuitem><guimenuitem> Filter By... </guimenuitem>
-        </menuchoice>
-        , then only transactions in that account and shown by the filter will be searched.
+        Search results differ depending on the tab from which you open
+        it. Aside from the transaction fields Description, Number,
+        Notes, and Date Posted, all of the searchable fields are part
+        of individual splits, and splits are associated with a single
+        account. When you open the <guilabel>Find
+        Transactions</guilabel> dialog from an account register tab
+        only the splits associated with that register will be
+        searched. There is one exception, the <guilabel>All
+        Accounts</guilabel> item, see the footnote about it in table
+        <xref linkend="tool-find-bttns"/> below. For the transactions
+        fields only transactions linked to a split in that register
+        are inspecected and for the rest only the split attached to
+        that account is, with one exception, <guilabel>All
+        Accounts</guilabel>. If you filter the transactions in a
+        register using <menuchoice> <guimenuitem>View
+        </guimenuitem><guimenuitem> Filter By... </guimenuitem>
+        </menuchoice> , then only transactions in that account and
+        shown by the filter will be searched. If you start from the
+        Accounts page or a <link linkend="general-journal">General
+        Journal</link> register then all splits in all applicable
+        transactions (in the latter case those included in the
+        register) are inspected.
       </para>
 
       <note>
@@ -1161,10 +1175,21 @@
               <entry morerows="1" valign="middle">
                 <para>Account
                   <footnote>
-                    <para>The <guilabel>Account</guilabel> option performs a search where the accounts selected in the
-                      <guilabel>Choose Accounts</guilabel> dialog will both be searched individually
-                      for results. This means that a match in any of the selected accounts will
-                      either be displayed (matches any account) or discarded (matches no account).
+                    <para>When the <guilabel>Find
+                    Transactions</guilabel> dialog is started from the
+                    <guilabel>Accounts</guilabel> tab or a
+                    <guilabel>General Journal</guilabel> register the
+                    <guilabel>Account</guilabel> option performs a
+                    search where the accounts selected in the
+                    <guilabel>Choose Accounts</guilabel> dialog will
+                    both be searched individually for results. This
+                    means that a match in any of the selected accounts
+                    will either be displayed (matches any account) or
+                    discarded (matches no account). If the
+                    <guilabel>FindTransactions</guilabel> dialog is
+                    started in a regular account register and the
+                    current account is selected return all of the
+                    transactions or if it is not, no transactions.
                     </para>
                   </footnote>
                 </para>
@@ -1213,9 +1238,25 @@
               <entry>
                 <para>All Accounts
                   <footnote>
-                    <para>The <guilabel>All Accounts</guilabel> option performs a search where accounts selected in the
-                      <guilabel>Choose Accounts</guilabel> dialog will only return results that
-                      match in both accounts.
+                    <para>The <guilabel>All Accounts</guilabel> option
+                    performs a search where accounts selected in the
+                    <guilabel>Choose Accounts</guilabel> dialog will
+                    return transactions containing at least one split
+                    in every one of the accounts chosen. When run from
+                    a regular account register this is the only
+                    criterion that will inspect splits from other
+                    accounts so if you start the <guilabel>Find
+                    Transactions</guilabel> dialog from your
+                    Assets:Current Assets:Checking register and want
+                    to find all of the transactions in that account
+                    with a split in Expenses:Groceries, this is the
+                    criterion to use. Keep in mind, though, that it's
+                    an "and" search: If you also include Expenses:Misc
+                    it will find <emphasis role="italic">only</emphasis>
+                    those transactions with a split in each of the
+                    two, <emphasis role="italic">not</emphasis>
+                    transactions with a single split in either of
+                    them.
                     </para>
                   </footnote>
                 </para>

--- a/manual/C/Help_ch_Tools_Assistants.xml
+++ b/manual/C/Help_ch_Tools_Assistants.xml
@@ -249,7 +249,7 @@
               <entry morerows="2" valign="middle">
                 <para>Description
                   <footnote id="DMN">
-                    <para>The Description, Number, and Notes fields belong to the transaction, all other searchable fields are part of individual splits.
+                    <para>The Description, Number, Notes, and Date Posted fields belong to the transaction, all other searchable fields are part of individual splits.
                     </para>
                   </footnote>
                 </para>
@@ -647,7 +647,7 @@
 
             <row>
               <entry morerows="5" valign="middle">
-                <para>Date Posted
+                <para>Date Posted<footnoteref linkend="DMN"/>
                 </para>
               </entry>
 
@@ -1091,7 +1091,7 @@
             </row>
 
             <row>
-              <entry morerows="1" valign="middle">
+              <entry>
                 <para>Closing Entries
                 <footnote>
                   <para>The Closing Entries selection will find transactions whose split is marked as a closing entry by <menuchoice><guimenu>Tools</guimenu><guimenuitem>Close Book</guimenuitem></menuchoice>.

--- a/manual/C/Help_ch_Tools_Assistants.xml
+++ b/manual/C/Help_ch_Tools_Assistants.xml
@@ -46,7 +46,7 @@
   <sect1 id="tool-find">
     <title>Find</title>
 
-    <para>The &app; <emphasis>Find</emphasis> assistant can be used to <link linkend="tool-find-txn">find
+    <para>The &app; <emphasis>Find</emphasis> dialog can be used to <link linkend="tool-find-txn">find
       transactions</link> or to perform <link linkend="tool-find-bsnss">business related</link>
       research on your data file.
     </para>

--- a/manual/C/Help_ch_Tools_Assistants.xml
+++ b/manual/C/Help_ch_Tools_Assistants.xml
@@ -295,7 +295,113 @@
 
             <row>
               <entry morerows="2" valign="middle">
+                <para>Notes<footnoteref linkend="DMN"/>
+                </para>
+              </entry>
+
+              <entry>
+                <para>contains
+                </para>
+              </entry>
+
+              <entry morerows="2" valign="middle">
+                <para>Criteria entry field
+                </para>
+              </entry>
+
+              <entry morerows="2" valign="middle">
+                <para>Is entry Case Insensitive?
+                </para>
+              </entry>
+
+              <entry morerows="2" valign="middle">
+                <para>Remove row
+                </para>
+              </entry>
+
+              <entry morerows="2" valign="middle">
+                <para></para>
+              </entry>
+
+              <entry morerows="2" valign="middle">
+                <para></para>
+              </entry>
+
+              <entry morerows="2" valign="middle">
+                <para></para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>matches regex<footnoteref linkend="rgx"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>does not match regex<footnoteref linkend="rgx"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry morerows="2" valign="middle">
                 <para>Memo
+                </para>
+              </entry>
+
+              <entry>
+                <para>contains
+                </para>
+              </entry>
+
+              <entry morerows="2" valign="middle">
+                <para>Criteria entry field
+                </para>
+              </entry>
+
+              <entry morerows="2" valign="middle">
+                <para>Is entry Case Insensitive?
+                </para>
+              </entry>
+
+              <entry morerows="2" valign="middle">
+                <para>Remove row
+                </para>
+              </entry>
+
+              <entry morerows="2" valign="middle">
+                <para></para>
+              </entry>
+
+              <entry morerows="2" valign="middle">
+                <para></para>
+              </entry>
+
+              <entry morerows="2" valign="middle">
+                <para></para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>matches regex<footnoteref linkend="rgx"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>does not match regex<footnoteref linkend="rgx"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry morerows="2" valign="middle">
+                <para>Description, Notes, or Memo<footnote><para>Searches for a term in the transaction's Description and Notes fields and the Split's Memo field.</para></footnote>
                 </para>
               </entry>
 
@@ -453,54 +559,74 @@
             </row>
 
             <row>
-              <entry morerows="2" valign="middle">
-                <para>Notes<footnoteref linkend="DMN"/>
+              <entry morerows="5" valign="middle">
+                <para>Reconciled Date
                 </para>
               </entry>
 
               <entry>
-                <para>contains
+                <para>is before
                 </para>
               </entry>
 
-              <entry morerows="2" valign="middle">
-                <para>Criteria entry field
+              <entry morerows="5" valign="middle">
+                <para>Date selection field
                 </para>
               </entry>
 
-              <entry morerows="2" valign="middle">
-                <para>Is entry Case Insensitive?
-                </para>
-              </entry>
-
-              <entry morerows="2" valign="middle">
+              <entry morerows="5" valign="middle">
                 <para>Remove row
                 </para>
               </entry>
 
-              <entry morerows="2" valign="middle">
+              <entry morerows="5" valign="middle">
                 <para></para>
               </entry>
 
-              <entry morerows="2" valign="middle">
+              <entry morerows="5" valign="middle">
                 <para></para>
               </entry>
 
-              <entry morerows="2" valign="middle">
+              <entry morerows="5" valign="middle">
+                <para></para>
+              </entry>
+
+              <entry morerows="5" valign="middle">
                 <para></para>
               </entry>
             </row>
 
             <row>
               <entry>
-                <para>matches regex<footnoteref linkend="rgx"/>
+                <para>is before or on
                 </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                <para>does not match regex<footnoteref linkend="rgx"/>
+                <para>is on
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>is not on
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>is after
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>is on or after
                 </para>
               </entry>
             </row>
@@ -952,46 +1078,82 @@
 
             <row>
               <entry morerows="1" valign="middle">
-                <para>Balanced
+                <para>Closing Entries
+                <footnote>
+                  <para>The Closing Entries selection will find transactions whose split is marked as a closing entry by <menuchoice><guimenu>Tools</guimenu><guimenuitem>Close Book</guimenuitem></menuchoice>.
+                  </para>
+                </footnote>
                 </para>
               </entry>
 
               <entry>
-                <para>is
+                <para>Check for true
                 </para>
               </entry>
 
-              <entry morerows="1" valign="middle">
-                <para>set true
-                </para>
-              </entry>
-
-              <entry morerows="1" valign="middle">
+              <entry>
                 <para>Remove row
                 </para>
               </entry>
 
-              <entry morerows="1" valign="middle">
+              <entry>
                 <para></para>
               </entry>
 
-              <entry morerows="1" valign="middle">
+              <entry>
                 <para></para>
               </entry>
 
-              <entry morerows="1" valign="middle">
+              <entry>
                 <para></para>
               </entry>
 
-              <entry morerows="1" valign="middle">
+              <entry>
+                <para></para>
+              </entry>
+
+              <entry>
                 <para></para>
               </entry>
             </row>
 
             <row>
               <entry>
-                <para>is not
+                <para>Balanced
+                <footnote>
+                  <para>Balanced finds transactions that are or are not balanced. Since &app; nearly always succeeds in balancing transactions this will almost always return all possible transactions. However it is possible to create a transaction containing multiple commodities that cannot be balanced and unchecking the box will find those transactions.</para>
+                </footnote>
                 </para>
+              </entry>
+
+              <entry>
+                <para>Check for true
+                </para>
+              </entry>
+
+              <entry>
+                <para>Remove row
+                </para>
+              </entry>
+
+              <entry >
+                <para> </para>
+              </entry>
+
+              <entry>
+                <para></para>
+              </entry>
+
+              <entry>
+                <para></para>
+              </entry>
+
+              <entry>
+                <para></para>
+              </entry>
+
+              <entry>
+                <para></para>
               </entry>
             </row>
 

--- a/manual/C/Help_ch_Tools_Assistants.xml
+++ b/manual/C/Help_ch_Tools_Assistants.xml
@@ -63,7 +63,8 @@
         .
       </para>
 
-      <para>Exactly which transactions are searched depends on where you invoke the tool from. If you start from
+      <para>
+        Exactly which transactions are searched depends on where you invoke the tool from. If you start from
         the main accounts hierarchy page, all transactions will be searched. If you start from an
         individual account register, only transactions in that account will be searched. And if you
         filter the transactions in a register using
@@ -163,7 +164,7 @@
         </para>
       </note>
 
-      <para>When search criteria are selected, you can press the <guibutton>Find</guibutton> button. You will be
+      <para>Once you've set the search criteria, you can press the <guibutton>Find</guibutton> button. You will be
         presented with the search results in a new register tab. A report of the search results may
         created and printed using
         <menuchoice>
@@ -234,7 +235,7 @@
               <entry morerows="2" valign="middle">
                 <para>Description
                   <footnote id="DMN">
-                    <para>The Description, Memo, Number are common to all lines in a transaction.
+                    <para>The Description, Number, and Notes fields belong to the transaction, all other searchable fields are part of individual splits.
                     </para>
                   </footnote>
                 </para>
@@ -294,7 +295,7 @@
 
             <row>
               <entry morerows="2" valign="middle">
-                <para>Memo<footnoteref linkend="DMN"/>
+                <para>Memo
                 </para>
               </entry>
 
@@ -453,7 +454,7 @@
 
             <row>
               <entry morerows="2" valign="middle">
-                <para>Notes
+                <para>Notes<footnoteref linkend="DMN"/>
                 </para>
               </entry>
 


### PR DESCRIPTION
This is inspired by [Bug 798472](https://bugs.gnucash.org/show_bug.cgi?id=798472) in which the reporter says that the docs aren't clear about what gets searched. On investigation that proved true; what's more the section hadn't been maintained in a while and there were several criteria available that weren't documented. The Search Criteria table also incorrectly claimed that "memo" is a transaction field and that "notes" is not; the reverse is true.