### PR TITLE
Check images

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists.txt for GnuCash Documenation
 
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.10)
 
 # This sets a number of environment variables we can use later on
 # The names of these variables start with PROJECT_ and gnucash-docs_VERSION

--- a/cmake/AddGncDocTargets.cmake
+++ b/cmake/AddGncDocTargets.cmake
@@ -14,6 +14,12 @@ function (add_gnc_doc_targets docname entities)
                                 --noout
                                 --path ${CMAKE_SOURCE_DIR}/docbook
                                 ${CMAKE_CURRENT_SOURCE_DIR}/${docname}.xml
+            COMMAND  ${CMAKE_COMMAND}
+                -D XMLLINT=${XMLLINT}
+                -D GNC_SOURCE_DIR=${CMAKE_SOURCE_DIR}
+                -D GNC_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+                -D docname=${docname}
+                -P ${CMAKE_SOURCE_DIR}/cmake/CheckFigures.cmake
             DEPENDS ${entities} "${docname}.xml" "${CMAKE_SOURCE_DIR}/docbook/gnc-docbookx.dtd")
         add_dependencies(${docname}-check "${lang}-${docname}-check")
     endif()

--- a/cmake/CheckFigures.cmake
+++ b/cmake/CheckFigures.cmake
@@ -1,0 +1,52 @@
+execute_process(
+    COMMAND ${XMLLINT} --postvalid
+                       --xinclude
+                       --path ${GNC_SOURCE_DIR}/docbook
+                       --xpath "//imagedata/@fileref"
+                       ${GNC_CURRENT_SOURCE_DIR}/${docname}.xml
+    RESULT_VARIABLE LINT_RESULT
+    OUTPUT_VARIABLE xml_figures
+)
+if (NOT ${LINT_RESULT} STREQUAL "0")
+    message(FATAL_ERROR "Error while scanning document for referenced images: ${LINT_RESULT}")
+endif()
+
+set(fullpath_xml_figures "")
+set(missing_img_files "")
+
+get_filename_component(doc_lang ${GNC_CURRENT_SOURCE_DIR} NAME)
+
+string(REPLACE "\n" ";" xml_figures ${xml_figures})
+foreach(xml_figure ${xml_figures})
+    string (REGEX REPLACE "^.*=\"(.*)\"" "\\1" xml_figure ${xml_figure})
+    find_file(image ${xml_figure} ${GNC_CURRENT_SOURCE_DIR} NO_DEFAULT_PATH)
+    if(NOT image)
+        list(APPEND missing_img_files "  - ${xml_figure}")
+    else()
+        list(APPEND fullpath_xml_figures ${GNC_CURRENT_SOURCE_DIR}/${xml_figure})
+    endif()
+endforeach()
+
+if(missing_img_files)
+    string(REPLACE ";" "\n" missing_img_files "${missing_img_files}")
+    string(PREPEND missing_img_files "  Following non-existing images are referenced in document ${docname}(${doc_lang}):\n")
+    message(WARNING ${missing_img_files})
+endif()
+
+set(unused_img_files "")
+file(GLOB_RECURSE images
+    "${GNC_CURRENT_SOURCE_DIR}/figures/*.png"
+    "${GNC_CURRENT_SOURCE_DIR}/figures/*.svg")
+
+foreach(image ${images})
+    list(FIND fullpath_xml_figures "${image}" result)
+    if (${result} EQUAL -1)
+        list(APPEND unused_img_files "    - ${image}")
+    endif()
+endforeach()
+
+if(unused_img_files)
+    string(REPLACE ";" "\n" unused_img_files "${unused_img_files}")
+    string(PREPEND unused_img_files " Note: following images exist but are not referenced in document ${docname}(${doc_lang}):\n")
+    message(STATUS ${unused_img_files})
+endif()


### PR DESCRIPTION
Extra checks for images. It will warn if a non-existent image is references in the documentation and notify if images in the figure directory are not referenced.

Both are potential issues:
* referencing non-existing images means the document isn't presented as intended
* having unreferenced images in the figures directory means we're needlessly installing files that are not unused, hence wasting disk space on users' computers

I started thinking of this issue after a [short IRC chat with @fellen](https://lists.gnucash.org/logs/2022/05/28.html#T04:25:28) recently. The discussion was about cmake not capturing when a new image was added. That problem can't be solved unless we explicitly list all used images in CMakeLists.txt files rather than the file glob we use currently.

This new check doesn't solve this issue either (it just can't), but it can be a useful tool to keep our used images in sync with our existing images. If we'd change our policy to explicitly list all images this check could be altered/extended to match existing images against the image list in CMakeLists.txt and against the image references in the documents themselves.