### PR TITLE
L10N:de: manual Remove obsolete cross references

### DIFF
--- a/manual/de/Help_ch_Account-Actions.xml
+++ b/manual/de/Help_ch_Account-Actions.xml
@@ -1025,25 +1025,6 @@
           <listitem>
             <para>Ein optionaler Nummernschlüssel wie in <xref linkend="accts-code" /> beschrieben.
             </para>
-<!-- FIXME source: new note -->
-            <note>
-              <para>Ähnlich der Kontonummer bietet der Typ eines Wertpapiers oder einer Währung eine Möglichkeit,
-                seine Investments sachlich zu sortieren. Grundsätzlich bietet es sich an, sie nach
-                Risiko zu gruppieren. Zum Beispiel kann als erste Ebene der Typ des Wertpapiers
-                angegeben werden und als optionale 2. Ebene die Nominalwährung.
-<screen>:
-|
-+--Bond
-|   |--CHF
-|   |--EUR
-+--Aktie
-|   |--CHF
-|   |--EUR
-|   |--GBP
-|
-:</screen>
-              </para>
-            </note>
           </listitem>
         </varlistentry>
 
@@ -1082,7 +1063,7 @@
                 <para>Werden mit dem Konto <guilabel>Aktien</guilabel> oder <guilabel>Investmentfonds</guilabel>
                   verwaltet, dann kann mit dem sich öffnenden Dialog <guilabel>Bitte wählen Sie
                   das Wertpapier</guilabel> auch ein neues Wertpapier erstellt werden. Dies wird in
-                  <xref linkend="tool-security-edit"></xref> beschrieben.
+                  <xref linkend="tool-commodity"></xref> beschrieben.
                 </para>
               </note>
             </para>
@@ -1368,25 +1349,6 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </sect2>
-
-    <sect2 id="accts-online-quotes">
-<!-- FIXME: move this section to section "tool-security-editor" -->
-      <title>Verwenden der Online-Kursaktualisierung</title>
-
-      <orderedlist>
-        <listitem>
-          <para>&app; bedient sich eines externen Tools zum Abrufen von Online-Kursen. Dieses Tool ist ein
-            &app-perl;-Modul namens &app-fq; und muss zusätzlich zu &app; auf Ihrem Computer
-            installiert sein.
-          </para>
-
-          <tip>
-            <para>Die Installation wird in <xref linkend="finance-quote" /> detailiert beschrieben.
-            </para>
-          </tip>
-        </listitem>
-      </orderedlist>
     </sect2>
   </sect1>
 

--- a/manual/de/Help_ch_Tools_Assistants.xml
+++ b/manual/de/Help_ch_Tools_Assistants.xml
@@ -5929,22 +5929,6 @@ and update the appendix. -->
         </varlistentry>
       </variablelist>
     </sect2>
-
-    <sect2 id="invest-stockprice-online3">
-      <title>Konfigurieren von Wertpapieren/Währungen für den Online-Abruf von Kursen</title>
-<!-- FIXME remove this chapter -->
-<!-- 
-      <para>Um Online-Kurse für eine bestimmte Aktie oder ein Investmentfonds-Konto zu nutzen, müssen Sie
-        zunächst <guilabel>Börsenkurse online abrufen</guilabel> aktivieren und eine Kursquelle im
-        Wertpapier-Editor auswählen. Für die Online-Aktualisierung von Währungskursen müssen nur
-        die Zeitzone ausgewählt werden und das Kästchen <guilabel>Börsenkurse online
-        abrufen</guilabel> im Wertpapier-Editor aktiviert sein.
-      </para>
- -->
-      <para>Detaillierte Anweisungen finden Sie im Abschnitt "Neue Konten erstellen":
-        <xref linkend="accts-online-quotes"></xref>
-      </para>
-    </sect2>
   </sect1>
 
   <sect1 id="tool-calc">


### PR DESCRIPTION
For compatibility reasons some xrefs between ch_Account-Actions and
ch_Tools-Assistants were still maintained which have now been cleaned
up.