### PR TITLE
some stock entry clarifications

### DIFF
--- a/C/guide/ch_invest.xml
+++ b/C/guide/ch_invest.xml
@@ -764,10 +764,9 @@ Income
                 </listitem>
 
                 <listitem>
-                  <para>The <guilabel>Type:</guilabel> should already be <guilabel>NASDAQ</guilabel>, because this is what
-                    was selected in the security selector, but you can change it here, including
-                    adding more categories. More information about this can be found in the &app;
-                    Manual in section 8.7, <quote>Security Editor</quote>.
+                  <para><guilabel>Type:</guilabel> will already be <guilabel>NASDAQ</guilabel>, if you completed the example setup in the previous section,
+                    because this was selected in the security selector. If you want, you can change it here, including
+                    adding more categories. More information about this can be found in <ulink url="&url-docs-C;help/tool-security-edit.html">the Security Editor manual page</ulink>.
                   </para>
                 </listitem>
 

--- a/C/manual/ch_Tools_Assistants.xml
+++ b/C/manual/ch_Tools_Assistants.xml
@@ -4857,7 +4857,7 @@
   <sect1 id="stock-assistant">
     <title>Recording a Stock Transaction</title>
     <para>While with practice you can quickly enter any stock transaction directly in the register as explained in the <quote>Investments</quote> chapter in the guide, &app; provides an assistant that can help walk you through most common transactions and several less common ones that you might encounter.</para>
-    <para>The assistant is accessed from the <guilabel>Action</guilabel> menu when the current register is for a Stock or Mutual Fund account.</para>
+    <para>The assistant is accessed from the <guilabel>Action</guilabel> menu when the current register is for a non-placeholder Stock or Mutual Fund account. If you are trying to use the assistant but it is disabled, you may need to complete the steps in <ulink url="&url-docs-C;guide/invest-setup1.html#invest-setup-stockaccounts2">Setup Accounts for Stocks and Mutual Funds</ulink> first.</para>
 
     <itemizedlist>
       <title>Types of stock transactions supported by the <guilabel>Stock Transaction Assistant</guilabel></title>
@@ -5324,44 +5324,10 @@
 
     <itemizedlist>
       <listitem>
-        <para><emphasis role="bold">Type:</emphasis> Categories for organizing securities. &app; has the following
-          built in:
-          <itemizedlist>
-            <listitem>
-              <para><guilabel>CURRENCY</guilabel> or <guilabel>ISO4317</guilabel>: These are used for national
-                currencies and are not editable with the <guilabel>Security Editor</guilabel>.
-              </para>
-            </listitem>
-
-            <listitem>
-              <para><guilabel>FUND</guilabel>: Ordinarily used for open-ended mutual funds, i.e., those that one
-                purchases from and sells to only the issuing company and that are priced daily at
-                their net asset value.
-              </para>
-            </listitem>
-
-            <listitem>
-              <para><guilabel>AMEX</guilabel>, <guilabel>ASX</guilabel>, <guilabel>EUREX</guilabel>,
-                <guilabel>NASDAQ</guilabel>, and <guilabel>NYSE</guilabel>: These represent a few of
-                the exchanges on which stocks, closed-end mutual funds, and exchange-traded funds
-                are traded.
-              </para>
-            </listitem>
-
-            <listitem>
-              <para><guilabel>Template</guilabel>: This is a reserved word. It will not normally appear in the
-                <guilabel>Security Editor</guilabel> unless you type it in, and if you do it will
-                cause problems. Don&apos;t use it.
-              </para>
-            </listitem>
-          </itemizedlist>
-        </para>
-
-        <para>If your investment doesn&apos;t fit into one of these categories, for example if you trade stocks on
-          the DAX or LSE, you can easily create your own type simply by typing it into the field.
-          The type of security has no meaning to Gnucash (except <guilabel>Template</guilabel>,
-          don&apos;t use that!), it&apos;s there only to make it easier for you to find the security
-          from the selection lists.
+        <para><emphasis role="bold">Type:</emphasis> Categories for organizing securities. You can use any name
+        you like here except for the word <guilabel>Template</guilabel>. Some common choices are <guilabel>EUREX</guilabel>
+        and <guilabel>NASDAQ</guilabel>, but the type of security has no meaning to Gnucash (except <guilabel>Template</guilabel>,
+          don&apos;t use that!). It&apos;s there only to make it easier for you to find the security from the selection lists.
         </para>
       </listitem>
 


### PR DESCRIPTION
I'm a new gnucash user and found a few things unintuitive. Here are some proposed doc improvements I think would've helped me:

- be a bit more descriptive when mentioning where the `NASDAQ` field came from
- link to the security editor manual page so the reader doesn't have to hunt for it
- replace the bit about how gnucash "has the following built in:" (since these categories are no longer automatically included) with 2 suggested examples
- explain why the stock transaction assistant menu item might be disabled

It's my first PR here, all feedback welcome.