### PR TITLE
F::Q: further improvment

### DIFF
--- a/C/guide/appendixd.xml
+++ b/C/guide/appendixd.xml
@@ -758,7 +758,7 @@ Blocking_Chars</literallayout>
                     <guimenu>File</guimenu><guimenuitem>Properties </guimenuitem>
                   </menuchoice>
                   for number source (transaction number or anchor-split action - see
-                  <ulink url="&url-docs-C;help/book-options.html#num-action-book-option">Use Split
+                  <ulink url="&url-docs-C;manual/book-options.html#num-action-book-option">Use Split
                   Action Field for Number</ulink> in the Book Options section of the &app; Manual).
                 </entry>
               </row>
@@ -806,7 +806,7 @@ Blocking_Chars</literallayout>
                     <guimenu>File</guimenu><guimenuitem> Properties</guimenuitem>
                   </menuchoice>
                   for number source (transaction number or anchor-split action - see
-                  <ulink url="&url-docs-C;help/book-options.html#num-action-book-option">Use Split
+                  <ulink url="&url-docs-C;manual/book-options.html#num-action-book-option">Use Split
                   Action Field for Number</ulink> in the Book Options section of the &app; Manual).
                   If number source for the book is specified as anchor-split action, this field will
                   instead print the transaction number field.

--- a/C/guide/appendixd.xml
+++ b/C/guide/appendixd.xml
@@ -755,7 +755,7 @@ Blocking_Chars</literallayout>
                   This type value tells &app; to print the check number at the specified
                   coordinates. The check number reflects the book option selection under
                   <menuchoice>
-                    <guimenu>File</guimenu><guimenuitem>Properties </guimenuitem>
+                    <guimenu>File</guimenu><guimenuitem>Properties</guimenuitem>
                   </menuchoice>
                   for number source (transaction number or anchor-split action - see
                   <ulink url="&url-docs-C;manual/book-options.html#num-action-book-option">Use Split
@@ -803,7 +803,7 @@ Blocking_Chars</literallayout>
                   This type value tells &app; to print the split action field at the specified
                   coordinates. However, the printed field reflects the book option selection under
                   <menuchoice>
-                    <guimenu>File</guimenu><guimenuitem> Properties</guimenuitem>
+                    <guimenu>File</guimenu><guimenuitem>Properties</guimenuitem>
                   </menuchoice>
                   for number source (transaction number or anchor-split action - see
                   <ulink url="&url-docs-C;manual/book-options.html#num-action-book-option">Use Split

--- a/C/guide/ch_basics.xml
+++ b/C/guide/ch_basics.xml
@@ -843,7 +843,7 @@ Translators:
 
           <listitem>
             <simpara>You can also change the alignment of the tab bar by changing the <guilabel>Tab Position</guilabel>
-              in <ulink url="&url-docs-C;help/set-prefs.html#prefs-window">The Preferences window,
+              in <ulink url="&url-docs-C;manual/set-prefs.html#prefs-window">The Preferences window,
               Windows tab</ulink>.
             </simpara>
           </listitem>

--- a/C/guide/ch_bus_features.xml
+++ b/C/guide/ch_bus_features.xml
@@ -1716,7 +1716,7 @@
               <guimenu>Reports</guimenu><guimenuitem>Account Report </guimenuitem>
             </menuchoice>
             . Further formatting or analysis may be done by copying and pasting the report into a
-            spreadsheet. See <ulink url="&url-docs-C;help/tool-find.html?tool-find-txn">Find
+            spreadsheet. See <ulink url="&url-docs-C;manual/tool-find.html?tool-find-txn">Find
             Transaction</ulink> in the &app; Manual.
           </para>
         </note>

--- a/C/guide/ch_importing.xml
+++ b/C/guide/ch_importing.xml
@@ -23,7 +23,7 @@
     <important>
       <title>Outdated</title>
 
-      <para>This is an older version of <ulink url="&url-docs-C;help/trans-import.html"><quote>Common
+      <para>This is an older version of <ulink url="&url-docs-C;manual/trans-import.html"><quote>Common
         Transaction Operations</quote> in the manual</ulink>. Better continue there until this
         update anomaly is resolved.
       </para>

--- a/C/guide/ch_invest.xml
+++ b/C/guide/ch_invest.xml
@@ -814,7 +814,7 @@ Income
                   <note>
                     <para>If the <guibutton>Get Online Quotes</guibutton> button is not highlighted, and it is not tickable,
                       then the &app-fq; package is not installed. See the chapter
-                      <ulink url="&url-docs-C;help/finance-quote.html">Setting Up the Quote
+                      <ulink url="&url-docs-C;manual/finance-quote.html">Setting Up the Quote
                       Retrieval</ulink> in the manual.
                     </para>
                   </note>
@@ -1317,128 +1317,6 @@ Income
       <para>See the chapter <ulink url="&url-docs-C;help/finance-quote.html">Setting Up the Quote
         Retrieval</ulink> in the manual.
       </para>
-
-      <sect3 id="invest-stockprice-auto-install3">
-        <title>Installing &app-fq;</title>
-
-        <para>The process of installing &app-fq; depends on the system.
-        </para>
-
-        <para>On &lin; and BSD it's usually simplest to use the package manager, but those seldom keep up with the
-          latest &app-fq; releases. If you need a newer version than your package manager provides,
-          use the following procedure with <filename>gnc-fq-update</filename>
-        </para>
-
-        <procedure>
-          <title>Installing &app-fq; on &lin; with <filename>gnc-fq-update</filename></title>
-
-          <step>
-            <simpara>Close &app;.
-            </simpara>
-          </step>
-
-          <step>
-            <simpara>Run the command <command>which gnc-fq-update</command> to check <filename>gnc-fq-update</filename>
-              program is in your PATH environment variable.
-              <footnote>
-                <simpara>If you&rsquo;ve installed &app; packages provided by your distribution,
-                  <filename>gnc-fq-update</filename> must be on your PATH.
-                </simpara>
-              </footnote>
-            </simpara>
-
-            <substeps>
-              <step id="gnc-fq-update-not-found">
-                <simpara>If <filename>gnc-fq-update</filename> is not in your PATH, search the folder where &app; is
-                  installed.
-                </simpara>
-              </step>
-            </substeps>
-          </step>
-
-          <step>
-            <simpara>Run the command <command>sudo gnc-fq-update</command> or <command>su -c gnc-fq-update</command> in
-              order to run it with root privilege. It depends on your distribution. If
-              <filename>gnc-fq-update</filename> is not in your PATH, specify full path of
-              <filename>gnc-fq-update</filename> instead, which is found by
-              <xref linkend="gnc-fq-update-not-found" />.
-            </simpara>
-
-            <para>This will launch a <application>Perl</application>
-              <acronym><ulink url="https://www.cpan.org/">CPAN</ulink></acronym>
-              <footnote>
-                <simpara>See <ulink url="https://www.cpan.org/misc/cpan-faq.html">CPAN Frequently Asked Questions</ulink> for
-                  details.
-                </simpara>
-              </footnote>
-              module internally. When you launch the CPAN module for the first time, you must setup
-              and configure it. However, on the most systems if you accept the default settings or
-              answer the first question <computeroutput>Are you ready for manual configuration?
-              [yes]</computeroutput> with <userinput>no</userinput>, you will be able to install
-              &app-fq; successfully.
-            </para>
-          </step>
-
-          <step>
-            <simpara>Run <command>gnc-fq-dump</command> to check &app-fq; works properly.
-            </simpara>
-          </step>
-        </procedure>
-
-        <procedure>
-          <title>Installing &app-fq; on &mac;</title>
-
-          <step>
-            <simpara>Close &app;.
-            </simpara>
-          </step>
-
-          <step>
-            <simpara>Install Xcode if it is not installed.
-            </simpara>
-
-            <simpara>XCode is an optional item from your &mac; distribution DVD.
-            </simpara>
-          </step>
-
-          <step>
-            <simpara>Run the <emphasis>Update Finance Quote</emphasis> app in the &app; dmg.
-            </simpara>
-
-            <para>You can run it from the dmg or copy it to the same folder to which you copied &app;. It will open a
-              Terminal window and run a script for you which will ask lots of questions. Accept the
-              default for each unless you know what you&rsquo;re doing.
-            </para>
-          </step>
-        </procedure>
-
-        <procedure>
-          <title>Installing &app-fq; on &win;</title>
-
-          <step>
-            <simpara>Close &app;.
-            </simpara>
-          </step>
-
-          <step>
-            <simpara>Run
-              <menuchoice>
-                <guimenu>Start</guimenu> <guisubmenu>&app;</guisubmenu> <guimenuitem>Install Online
-                Price Retrieval</guimenuitem>
-              </menuchoice>
-              .
-            </simpara>
-          </step>
-        </procedure>
-
-        <note>
-          <para>If you feel uncomfortable about performing any of these steps, please either email the &app;-user
-            mailing list (<email>gnucash-user@gnucash.org</email>) for help or come to the &app; IRC
-            channel on irc.gnome.org. You can also leave out this step and manually update your
-            stock prices.
-          </para>
-        </note>
-      </sect3>
 
       <sect3 id="invest-stockprice-auto-configure3">
         <title>Configuring Securities for Online Quotes</title>

--- a/C/guide/ch_invest.xml
+++ b/C/guide/ch_invest.xml
@@ -1314,7 +1314,7 @@ Income
         activate this feature.
       </para>
 
-      <para>See the chapter <ulink url="&url-docs-C;help/finance-quote.html">Setting Up the Quote
+      <para>See the chapter <ulink url="&url-docs-C;manual/finance-quote.html">Setting Up the Quote
         Retrieval</ulink> in the manual.
       </para>
 
@@ -3234,7 +3234,7 @@ Income
         </figure>
 
         <para>Refer to the Help Manual, Chapter 8 Tools &amp; Assistants,
-          <ulink url="&url-docs-C;help/tool-lots.html">Lots in Account</ulink> for details of the
+          <ulink url="&url-docs-C;manual/tool-lots.html">Lots in Account</ulink> for details of the
           Lots in Account screen elements.
         </para>
       </sect3>

--- a/C/guide/ch_reports.xml
+++ b/C/guide/ch_reports.xml
@@ -385,7 +385,7 @@
         </itemizedlist>
 
         <para>For more details, see the
-          <ulink url="&url-docs-C;help/report-classes.html#investment-lots-report">Investment
+          <ulink url="&url-docs-C;manual/report-classes.html#investment-lots-report">Investment
           Lots</ulink> report documentation in the Manual.
         </para>
       </sect3>

--- a/C/manual/ch_Finance-Quote.xml
+++ b/C/manual/ch_Finance-Quote.xml
@@ -182,7 +182,7 @@ SYNOPSIS
           already in a directory that is entered in the <envar>PATH</envar> environment variable.
           <footnote>
             <simpara>If you&rsquo;ve installed &app; packages provided by your distribution,
-              <filename>gnucash-cli</filename> must be on your <envar>PATH</envar>. The currentness
+              &app-cli; must be on your <envar>PATH</envar>. The currentness
               of your distribution can be checked under
               <ulink url="&url-repo;perl:finance-quote/versions"><citetitle>&app-fq;-
               versions</citetitle></ulink>.

--- a/C/manual/ch_Finance-Quote.xml
+++ b/C/manual/ch_Finance-Quote.xml
@@ -105,17 +105,6 @@ This is perl 5, version 30, subversion 0 (v5.30.0) built for x86_64-linux-gnu-th
       <step>
         <para>Under &win; run the program &gmi.winOS.inst-fq; to run. This will install
           <ulink url="&url-wp-en;Strawberry_Perl">Strawberry Perl</ulink>.
-          <footnote>
-            <para>&app; Version 2.2.6 and before require <ulink url="&url-wp-en;ActivePerl">ActivePerl</ulink>. in
-              version 5.8.
-            </para>
-          </footnote>
-
-          <footnote>
-            <para>&app; Version 2.4 and before require <ulink url="&url-wp-en;ActivePerl">ActivePerl</ulink> Version
-              5.16.3 and later.
-            </para>
-          </footnote>
         </para>
       </step>
 
@@ -148,7 +137,7 @@ This is perl 5, version 30, subversion 0 (v5.30.0) built for x86_64-linux-gnu-th
 
     <para>To determine if the &app-perl; module &app-fq; is already installed on your system, type
       <userinput>perldoc Finance::Quote</userinput> in a terminal window and check to see if there
-      is any documentation
+      is any documentation available.
       <informalexample>
 <?dbfo pgwide="1"?>
 <screen language="console">
@@ -160,7 +149,7 @@ SYNOPSIS
     [...]
 </screen>
       </informalexample>
-      available. If you are now shown documentation, then &app-fq; is already installed and you can
+      If you are now shown documentation, then &app-fq; is already installed and you can
       configure periodical quotes update as described in <xref linkend="fq-auto-quote" />. If no
       documentation is displayed, you will have to continue with this chapter.
     </para>
@@ -178,29 +167,27 @@ SYNOPSIS
       </step>
 
       <step>
+        <simpara>Next, update &app-fq; with <userinput>sudo gnc-fq-update</userinput>.
+        </simpara>
+      </step>
+
+      <step>
         <simpara>Run the <userinput>gnucash-cli --quotes info</userinput> command to verify that the program is
           already in a directory that is entered in the <envar>PATH</envar> environment variable.
           <footnote>
-            <simpara>If you&rsquo;ve installed &app; packages provided by your distribution,
-              &app-cli; must be on your <envar>PATH</envar>. The currentness
-              of your distribution can be checked under
-              <ulink url="&url-repo;perl:finance-quote/versions"><citetitle>&app-fq;-
-              versions</citetitle></ulink>.
+            <simpara>If you&rsquo;ve installed &app; packages provided by your distribution, &app-cli; will be on your
+              <envar>PATH</envar>. The &app-fq; version provided by your package manager can be checked
+              at <ulink url="&url-repo;perl:finance-quote/versions">
+              <citetitle>&app-fq;-versions</citetitle></ulink> or by using your package manager's info command.
             </simpara>
           </footnote>
         </simpara>
       </step>
 
       <step>
-        <simpara>Next, update &app-fq; with <userinput>sudo gnc-fq-update</userinput>.
-        </simpara>
-      </step>
-
-      <step>
-        <simpara>Run <userinput>gnucash-cli --quotes info</userinput> to check &app-fq; works properly. This command
-          returns the version number of &app-fq; module currently installed as well as a list of
-          sources available via the &app-fq; module. It will also inform you if there is a problem
-          with your installation or if it is missing, and may suggest a fix.
+        <simpara>If &app-fq; works properly, the command returns the version number of &app-fq; module currently
+          installed as well as a list of sources available via the &app-fq; module. It will also inform
+          you if there is a problem with your installation or if it is missing, and may suggest a fix.
         </simpara>
       </step>
     </procedure>
@@ -278,17 +265,44 @@ SYNOPSIS
     <title>Using &app-cli; for Testing and Automation.</title>
 
     <abstract>
-      <para>&app; provides a commandline facility &app-cli; that one can use in a terminal session to check the
+      <para>&app; provides a commandline facility &app-cli; that one can use with the
+        <replaceable>--quotes</replaceable> option in a terminal session to check the
         version and supported source modules, to display the quotes or exchange rates for selected
         securities or currencies, or to update all of the prices in a book without launching the
         GUI.
       </para>
     </abstract>
 
+    <note>
+      <para>In &app; version 4.x and earlier one used separate perl programs <userinput>gnc-fq-check</userinput>
+        instead of <userinput>gnucash-cli --quote info</userinput> and <userinput>gnc-fq-dump</userinput>
+        instead of <userinput>gnucash-cli --quote dump</userinput>.
+      </para>
+    </note>
+
     <sect2 id="fq-check-version">
       <title>Displaying the Finance::Quote Version and Supported Sources</title>
 
-      <para><command>gnucash-cli --quotes info</command> produces the following output:
+      <abstract>
+        <para>The <replaceable>--quotes info</replaceable> option returns the version number of the currently
+          installed &app-fq; module and a list of available sources. It informs you also if there is
+          a problem with your installation and gives the reasons.
+        </para>
+      </abstract>
+
+      <para>The latest &app-fq; version is &app-fq-vers;. The list of sources that follows depends on the &app-fq; version.
+      </para>
+
+      <para>The input of
+        <cmdsynopsis>
+          <command>gnucash-cli</command>
+          <group choice="req">
+            <arg choice="plain">-Q</arg>
+            <arg choice="plain">--quotes</arg>
+          </group>
+          <arg choice="plain">info</arg>
+        </cmdsynopsis>
+        in the terminal produces the following output:
       </para>
 
       <informalexample>
@@ -316,10 +330,6 @@ yahoo_json   yahooweb     za
 </screen>
       </informalexample>
 
-      <para>The latest &app-fq; version is &app-fq-vers;. Depending on the actuality of your installation
-        the list of source modules made here may differ.
-      </para>
-
       <para>If there's a problem with your installation it will tell you about it. For example in this case
         we're missing the Perl modules Finance::Quote and JSON::Parse:
       </para>
@@ -332,8 +342,8 @@ Failed to initialize Finance::Quote: missing_modules Finance::Quote JSON::Parse
 </screen>
       </informalexample>
 
-      <para>In this case, &app-fq; is not installed correctly and therefore cannot be used for course retrieval with &app;.
-        Please install &app-fq; according to the instructions at
+      <para>In this case, &app-fq; is not installed correctly and therefore cannot be used for quote retrieval
+        with &app;. Please install &app-fq; according to the instructions at
         <xref linkend="fq-install" />.
       </para>
     </sect2>
@@ -341,16 +351,58 @@ Failed to initialize Finance::Quote: missing_modules Finance::Quote JSON::Parse
     <sect2 id="fq-print-quotes">
       <title>Displaying Quotes in a Terminal Window</title>
 
+      <abstract>
+        <para>The <replaceable>--quotes dump</replaceable> option provides quotes for a source and a list of of
+          symbols in a format that is easy for humans to read. This is useful to verify that a
+          particular online quote source is accessible and provides data.
+        </para>
+
+        <para>You can also check to see if the symbol you want to use for your online
+          price retrieval is available at the desired quote source.
+        </para>
+      </abstract>
+
+      <tip>
+        <para>You may use <userinput>gnucash-cli --quotes dump</userinput> to test quote sources and symbols 
+          individually should &app; report an error during quote retrieval. The command will show
+          the fields required by &app;; use <userinput>gnucash-cli --verbose --quotes dump</userinput>
+          to see all of the information returned by &app-fq;.
+        </para>
+      </tip>
+
       <para>To display a quote for one or more stocks or the exchange rate for one or more currencies you can
-        use <userinput>gnucash-cli --quotes dump</userinput> as follows. It offers two output forms
-        for non-currency securities and one for currency exchange rates.
+        use <userinput>gnucash-cli --quotes dump</userinput> as follows:
+        <cmdsynopsis>
+          <command>gnucash-cli</command>
+          <group choice="req">
+            <arg choice="plain">-Q</arg>
+            <arg choice="plain">--quotes</arg>
+          </group>
+          <arg choice="plain">dump</arg>
+          <group choice="opt">
+            <arg choice="plain">-V</arg>
+            <arg choice="plain">--verbose</arg>
+          </group>
+           <arg choice="plain"><replaceable>Source</replaceable></arg>
+           <arg choice="plain" rep="repeat"><replaceable>Symbol</replaceable></arg>
+        </cmdsynopsis>
+      </para>
+
+      <para>It offers two output forms for non-currency securities and one for currency exchange rates.
         <variablelist>
           <varlistentry>
             <term>Currencies</term>
 
             <listitem>
-              <para>Currencies use the source <userinput>currency</userinput> and require at least two ISO-4217 currency
-                codes; the exchange rates are denominated in the first code. For example:
+              <para>Currencies use the source <userinput>currency</userinput> and require at least two
+                <ulink url="&url-wp-en;ISO_4217">ISO&nbsp;4217</ulink> currency codes; the exchange
+                rates are denominated in the first code.
+                <footnote>
+                  <para>Since &app-fq; 1.41 the default source for currencies is <quote>Alpha Vantage</quote>. See also the
+                    notes on <xref linkend="gnc-tbl-fq-currency-source" />.
+                  </para>
+                </footnote>
+                For example:
                 <informalexample>
 <?dbfo pgwide="1"?>
 <screen language="console">
@@ -368,12 +420,13 @@ $ gnucash-cli --quotes dump currency USD GBP EUR
             <term>Stocks</term>
 
             <listitem>
-              <itemizedlist>
-                <listitem>
-                  <para>A short form displaying only the fields that &app; uses along with comments indicating whether the
-                    fields are optional or required; you can use this to determine if &app; will be
-                    able to use the quote to update your book's price database.
-                    <informalexample>
+              <para>To retrieve quotes of your securities, please enter the quote source and the desired symbol.
+                <itemizedlist>
+                  <listitem>
+                    <para>A short form displaying only the fields that &app; uses along with comments indicating whether the
+                      fields are optional or required; you can use this to determine if &app; will
+                      be able to use the quote to update your book's price database.
+                      <informalexample>
 <?dbfo pgwide="1"?>
 <screen language="console">
 $ gnucash-cli --quotes dump yahooweb AAPL
@@ -385,18 +438,18 @@ Finance::Quote fields GnuCash uses:
        nav:                 &lt;=== one of these
      price:                 &lt;=/ 
 </screen>
-                    </informalexample>
-                  </para>
-                </listitem>
+                      </informalexample>
+                    </para>
+                  </listitem>
 
-                <listitem>
-                  <para>With the <userinput>-V</userinput> option a possibly longer output showing all of the fields
-                    &app-fq; returned. This can be useful to troubleshoot problems with a &app-fq;
-                    source module.
-                    <informalexample>
+                  <listitem>
+                    <para>With the <userinput>--verbose</userinput> option a possibly longer output showing all of the fields
+                      &app-fq; returned. This can be useful to troubleshoot problems with a &app-fq;
+                      source module.
+                      <informalexample>
 <?dbfo pgwide="1"?>
 <screen language="console">
-$ ALPHAVANTAGE_API_KEY=123456789 bin/gnucash-cli -V --quotes dump alphavantage INTC
+$ ALPHAVANTAGE_API_KEY=123456789 gnucash-cli --verbose --quotes dump alphavantage INTC
 INTC:
         open =&gt; 34.8200
      isodate =&gt; 2023-07-27
@@ -414,48 +467,80 @@ currency_set_by_fq =&gt; 1
     p_change =&gt; 0.5530
       method =&gt; alphavantage
 </screen>
-                    </informalexample>
+                      </informalexample>
 
-                    <note>
-                      <para>Notice that in this case we used alphavantage and provided the
-                        <userinput>ALPHAVANTAGE_API_KEY</userinput> on the command line. That's not
-                        necessary if the key is already stored in the shell environment or in &app;
-                        preferences.
-                      </para>
-                    </note>
-                  </para>
-                </listitem>
-              </itemizedlist>
+                      <note>
+                        <para>Notice that in this case we used alphavantage and provided the
+                          <userinput>ALPHAVANTAGE_API_KEY</userinput> on the command line. That's
+                          not necessary if the key is already stored in &mc.ed.pref;
+                          <xref linkend="prefs-online-quotes" />.
+                        </para>
+                      </note>
+                    </para>
+                  </listitem>
+                </itemizedlist>
+              </para>
             </listitem>
           </varlistentry>
         </variablelist>
       </para>
+
+      <procedure>
+        <para>To test if &app-fq; works for currencies inside &app;, do the following:
+        </para>
+
+          <step>
+            <para>create a transaction with the desired commodity in the book currency,
+            </para>
+          </step>
+
+          <step>
+            <para>make a right click on it,
+            </para>
+          </step>
+
+          <step>
+            <para>select &gmi.ac.ed-ex; in the context menu.
+            </para>
+          </step>
+
+          <step>
+            <para>In the <xref linkend="trans-win-enter" /> window click the <guilabel>Get exchange rate</guilabel> button.
+            </para>
+          </step>
+      </procedure>
+
+      <para>If the exchange rate source and the symbol are set, the current
+        rate will be entered in the exchange rate field.
+      </para>
     </sect2>
 
     <sect2 id="fq-auto-quote">
-      <title>Updating Prices Automatically with &app-cli;</title>
+      <title>Updating Quotes Automatically with &app-cli;</title>
 
       <para>With the command <command>gnucash-cli --quotes get &user-datafile;</command>
         <footnote>
-          <simpara>The old command <command>gnucash --add-price-quotes &user-datafile;</command> is obsolete as of &app; 5.0.
+          <simpara>This replaces the command <userinput>&app; --add-price-quotes &user-datafile;</userinput> in &app;
+            version 4.x and earlier.
           </simpara>
         </footnote>
-        you can receive the current prices of your foreign exchange and securities and write them directly into your
-        &app;-file without starting the user interface. This enables an automatic, regular updating of the prices.
+        you can receive the current prices of your foreign exchange and securities and write them
+        directly into your &app;-file without starting the user interface. This enables an
+        automatic, regular updating of the prices.
         <note>
-          <para>The command fails if exclusive access to the data file is not possible, for example,
-            the data file is opened in another &app; instance, or the last session for the file crashed.
+          <para>The command fails if exclusive access to the data file is not possible, for example, the data file
+            is opened in another &app; instance, or the last session for the file crashed.
           </para>
         </note>
       </para>
 
-      <para>The specified file &user-datafile; depends on the name and location of your
-        data file. This can be determined from the name displayed in the top frame of the &app;
-        window before the <quote>-</quote>.
+      <para>The specified file &user-datafile; depends on the name and location of your data file. This can be
+        determined from the name displayed in the top frame of the &app; window before the
+        <quote>-</quote>.
         <tip>
-          <para>The file name can also be found in the list of recently opened files in the &gm.file;menu.
-            If you hover the mouse pointer on the menu item numbered 1 in the list of recently opened files,
-            the full file name is displayed in the <guilabel>statusbar</guilabel>.
+          <para>The file name can also be found in the list of recently opened files in the &gm.file; menu. If you
+            hover the mouse pointer on the menu item numbered 1 in the list of recently opened
+            files, the full file name is displayed in the <guilabel>statusbar</guilabel>.
           </para>
         </tip>
       </para>

--- a/C/manual/tips-appendix.xml
+++ b/C/manual/tips-appendix.xml
@@ -155,7 +155,7 @@
                     </listitem>
 
                     <listitem>
-                      <para>To use him also with <command>gnc-fq-<replaceable>*</replaceable></command> commands you should set
+                      <para>To use him also with <command>gnucash-cli --quotes dump</command> commands you should set
                         an <emphasis>environment variable</emphasis>
                         <envar>ALPHAVANTAGE_API_KEY</envar>. Please consult the manual of your OS or
                         command shell.

--- a/C/manual/tips-appendix.xml
+++ b/C/manual/tips-appendix.xml
@@ -144,25 +144,7 @@
                     </listitem>
 
                     <listitem>
-                      <para>store the key which you got there in <link linkend="prefs-online-quotes">
-                        <menuchoice>
-                          <guimenu><accel>E</accel>dit</guimenu>
-                          <guimenuitem>Pr<accel>e</accel>ferences</guimenuitem> <guilabel>Online
-                          Quotes</guilabel>
-                        </menuchoice>
-                        </link>.
-                      </para>
-                    </listitem>
-
-                    <listitem>
-                      <para>To use him also with <command>gnucash-cli --quotes dump</command> commands you should set
-                        an <emphasis>environment variable</emphasis>
-                        <envar>ALPHAVANTAGE_API_KEY</envar>. Please consult the manual of your OS or
-                        command shell.
-                        <example>
-                          <title>Environment variable in <filename>.bashrc</filename></title>
-<programlisting language="bash">export ALPHAVANTAGE_API_KEY=<replaceable>##############</replaceable></programlisting>
-                        </example>
+                      <para>store the key which you got there in &mc.ed.pref; <xref linkend="prefs-online-quotes" />.
                       </para>
                     </listitem>
                   </orderedlist>

--- a/de/guide/ch_invest.xml
+++ b/de/guide/ch_invest.xml
@@ -878,9 +878,8 @@ Einnahmen
                   <note>
                     <para>Wenn die <guibutton>Börsenkurse Online abrufen</guibutton>-Schaltfläche nicht hervorgehoben ist,
                       und sie nicht angeklickt werden kann, dann ist das Paket
-                      <application>Finance::Quote</application> nicht installiert. Schauen Sie in
-                      den Abschnitt <link linkend="invest-stockprice-auto-install3">
-                      <quote>Installation <application>Finance::Quote</application></quote></link> .
+                      &app-fq; nicht installiert. Schauen Sie im &app;-Handbuch, in dem Kapitel
+                      <ulink url="&url-docs-de;manual/finance-quote.html">Einrichten der Kursabfrage</ulink> nach.
                     </para>
                   </note>
 
@@ -1289,77 +1288,6 @@ Einnahmen
         dort irgendeine Dokumentation verfügbar ist. Wenn Sie die Dokumentation sehen, dann ist das
         Modul installiert. Wenn Sie die Dokumentation nicht sehen, ist das Modul nicht installiert.
       </para>
-
-      <sect3 id="invest-stockprice-auto-install3">
-        <title><application>Finance::Quote</application> installieren</title>
-
-        <para>&win;:
-          <itemizedlist>
-            <listitem>
-              <para>Schließen Sie &app;.
-              </para>
-            </listitem>
-
-            <listitem>
-              <para>Starten Sie <emphasis role="strong">Install Online Price Retrieval</emphasis> im &app;
-                <quote>Start</quote> Menüeintrag.
-              </para>
-            </listitem>
-          </itemizedlist>
-        </para>
-
-        <para>&mac;: Sie müssen XCode installiert haben. XCode ist ein zusätzliches Element auf Ihrer &mac;
-          Distributions-DVD. Starten Sie die <emphasis role="strong">Finance Quote aktualisieren
-          </emphasis> App in &app;.dmg. Sie können es von dem *.dmg starten oder kopieren es in den
-          gleichen Ordner, in den Sie &app; kopiert haben. Es öffnet ein Terminalfenster und
-          startet ein Script für Sie, welches Ihnen viele Fragen stellt. Akzeptieren Sie die
-          Voreinstellungen, es sei denn, Sie wissen, was Sie tun.
-        </para>
-
-        <para>&lin;:
-          <itemizedlist>
-            <listitem>
-              <para>Schließen Sie jede laufende &app;-Instanz.
-              </para>
-            </listitem>
-
-            <listitem>
-              <para>Finden Sie den Ordner, wo &app; installiert ist, indem Sie nach
-                <application>gnc-fq-update</application> suchen.
-              </para>
-            </listitem>
-
-            <listitem>
-              <para>Öffnen Sie eine Root-Shell und wechseln in diesen Ordner
-              </para>
-            </listitem>
-
-            <listitem>
-              <para>Starten Sie das Kommando <command>gnc-fq-update</command>
-              </para>
-            </listitem>
-          </itemizedlist>
-          Dies führt eine <application>Perl</application> CPAN Sitzung zur Aktualisierung aus, die
-          sich mit dem Internet verbindet und das <application>Finance::Quote</application>-Modul
-          auf Ihrem System installiert. Das gnc-fq-update Programm ist interaktiv, trotzdem könnten
-          Sie auf den meisten Systemen auf die erste Frage mit <quote>Nein</quote> antworten:
-          <quote>Sind Sie bereit für eine händische Konfiguration [Ja]</quote> und die
-          Aktualisierung wird ab diesem Punkt automatisch fortgesetzt.
-        </para>
-
-        <para>Nach der vollständigen Installation sollten Sie das <quote> gnc-fq-dump</quote>-Testprogramm in dem
-          selben Verzeichnis mit &app; starten, um zu testen, ob
-          <application>Finance::Quote</application> richtig installiert ist und funktioniert.
-        </para>
-
-        <note>
-          <para>Wenn Sie sich unbehaglich bei der Durchführung der Schritte fühlen, mailen Sie entweder an die
-            &app;-user mailing list (<email>gnucash-de@gnucash.org</email>) und bitten um Hilfe oder
-            kommen in den <ulink url='&url-irc;'>#gnucash IRC-Kanal auf &srv-irc;</ulink>. Sie
-            können diesen Schritt auch auslassen und händisch die Preise der Aktien aktualisieren.
-          </para>
-        </note>
-      </sect3>
 
       <sect3 id="invest-stockprice-auto-configure3">
         <title>Wertpapiere für die Online-Abfrage konfigurieren</title>

--- a/de/guide/ch_invest.xml
+++ b/de/guide/ch_invest.xml
@@ -2130,7 +2130,7 @@ Einnahmen
           </screenshot>
         </figure>
 <!-- Fixme: Title still untranslated? -->
-        <para>Refer to the <ulink url="&url-docs-de;help/tool-lots.html"> Manual: Kapitel 8. Assistenten und
+        <para>Refer to the <ulink url="&url-docs-de;manual/tool-lots.html"> Manual: Kapitel 8. Assistenten und
           ähnliche Werkzeuge; Lose in Konto</ulink> für die Details von <quote>Lose in
           Konto</quote>-Fenstern.
         </para>

--- a/de/manual/ch_Finance-Quote.xml
+++ b/de/manual/ch_Finance-Quote.xml
@@ -181,12 +181,12 @@ SYNOPSIS
       </step>
 
       <step>
-        <simpara>Führen Sie den Befehl <userinput>gnc-fq-check</userinput> aus, um zu überprüfen, ob das Programm
-          bereits in einem Verzeichnis liegt, welches in der Umgebungsvariable <envar>PATH</envar>
-          eingetragen ist.
+        <simpara>Führen Sie den Befehl <userinput>gnucash-cli --quotes info</userinput> aus, um zu
+          überprüfen, ob das Programm bereits in einem Verzeichnis liegt, welches in der
+          Umgebungsvariable <envar>PATH</envar> eingetragen ist.
           <footnote>
             <simpara>Wenn Sie die von Ihrer Distribution bereitgestellten &app; Pakete installiert haben, sollte
-              <filename>gnc-fq-check</filename> bereits in Ihrem <envar>PATH</envar> sein. Die
+              &app-cli; bereits in Ihrem <envar>PATH</envar> sein. Die
               Aktualität ihrer Distribution können Sie unter
               <ulink url="&url-repo;perl:finance-quote/versions"><citetitle>&app-fq;-
               Versionen</citetitle></ulink> nachlesen.

--- a/de/manual/ch_Finance-Quote.xml
+++ b/de/manual/ch_Finance-Quote.xml
@@ -107,17 +107,6 @@ This is perl 5, version 30, subversion 0 (v5.30.0) built for x86_64-linux-gnu-th
       <step>
         <para>Unter &win; führen Sie das Programm &mc.winOS.inst-fq; aus. Dies wird
           <ulink url="&url-wp-en;Strawberry_Perl">Strawberry Perl</ulink> installieren.
-          <footnote>
-            <para>&app; Version 2.2.6 und früher benötigen <ulink url="&url-wp-en;ActivePerl">ActivePerl</ulink> in
-              Version 5.8.
-            </para>
-          </footnote>
-
-          <footnote>
-            <para>&app; Version 2.4 und früher benötigen <ulink url="&url-wp-en;ActivePerl">ActivePerl</ulink> ab
-              Version 5.16.3.
-            </para>
-          </footnote>
         </para>
       </step>
 
@@ -181,31 +170,29 @@ SYNOPSIS
       </step>
 
       <step>
-        <simpara>Führen Sie den Befehl <userinput>gnucash-cli --quotes info</userinput> aus, um zu
-          überprüfen, ob das Programm bereits in einem Verzeichnis liegt, welches in der
-          Umgebungsvariable <envar>PATH</envar> eingetragen ist.
+        <simpara>Aktualisieren Sie &app-fq; mit <userinput>sudo gnc-fq-update</userinput>. Der Befehl
+          kann auch für eine Neuinstallation verwendet werden. Die richtige Syntax ist von der
+          jeweiligen Distribution abhängig.
+        </simpara>
+      </step>
+
+      <step>
+        <simpara>Führen Sie den Befehl <userinput>gnucash-cli --quotes info</userinput> aus, um zu überprüfen, ob
+          das Programm bereits in einem Verzeichnis liegt, welches in der Umgebungsvariable
+          <envar>PATH</envar> eingetragen ist.
           <footnote>
             <simpara>Wenn Sie die von Ihrer Distribution bereitgestellten &app; Pakete installiert haben, sollte
-              &app-cli; bereits in Ihrem <envar>PATH</envar> sein. Die
-              Aktualität ihrer Distribution können Sie unter
-              <ulink url="&url-repo;perl:finance-quote/versions"><citetitle>&app-fq;-
-              Versionen</citetitle></ulink> nachlesen.
+              &app-cli; bereits in Ihrem <envar>PATH</envar> sein. Die &app-fq; Version, die von Ihrem Paketmanager
+              bereitgestellt wird, kann unter <ulink url="&url-repo;perl:finance-quote/versions">
+              <citetitle>&app-fq;-versions</citetitle></ulink> nachgelesen werden oder mit dem info-Befehl
+              der Softwareverwaltung überprüft werden.
             </simpara>
           </footnote>
         </simpara>
-      </step>
 
-      <step>
-        <simpara>Als nächstes aktualisieren Sie &app-fq; mit <userinput>sudo gnc-fq-update</userinput>. Die richtige
-          Syntax ist von der jeweiligen Distribution abhängig.
-        </simpara>
-      </step>
-
-      <step>
-        <simpara>Führen Sie <userinput>gnucash-cli --quotes info</userinput> aus, um zu prüfen, ob &app-fq; richtig
-          installiert ist. Wenn dies so ist, dann werden die Versionsnummer sowie die von &app-fq;
+        <simpara>Ist &app-fq; richtig installiert ist, dann werden die Versionsnummer sowie die von &app-fq;
           verwendbaren Quellen für eine Kursabfrage aufgelistet. Bei Problemen mit der Installation
-          von &app-fq; wird eventuell eine Lösung vorgeschlagen.
+          wird eventuell eine Lösung vorgeschlagen.
         </simpara>
       </step>
     </procedure>
@@ -228,8 +215,8 @@ SYNOPSIS
         <simpara>Installieren Sie &app-xcode;
           <footnote>
             <para>Sie können &app-xcode; aus dem App Store installieren oder Sie installieren die viel kleineren
-              Xcode-Befehlszeilentools, indem Sie <userinput> sudo xcode-select
-              --install</userinput> in einer Terminal.app Eingabeaufforderung ausführen.
+              Xcode-Befehlszeilentools, indem Sie <userinput>sudo xcode-select --install</userinput>
+              in einer Terminal.app Eingabeaufforderung ausführen.
             </para>
           </footnote>
           , falls noch nicht geschehen. Es enthält Entwicklungswerkzeuge, die von CPAN benötigt
@@ -286,17 +273,45 @@ SYNOPSIS
     <title>Verwendung von &app-cli; für Tests und Automatisierung</title>
 
     <abstract>
-      <para>&app; enthält die Befehlszeilenanwendung &app-cli;, die in einer Terminalsitzung verwendet werden
-        kann, um die Version und die unterstützten Quellmodule zu prüfen, Kurse oder Wechselkurse
+      <para>&app; enthält die Befehlszeilenanwendung &app-cli;, welche mit der Option
+        <replaceable>--quotes</replaceable> in einer Terminalsitzung verwendet werden kann, um die
+        Version und die unterstützten Quellmodule von &app-fq; zu prüfen, Kurse oder Wechselkurse
         für ausgewählte Wertpapiere oder Währungen anzuzeigen und alle Kurse in einem Buch zu
-        aktualisieren, ohne die grafische Benutzeroberfläche zu starten.
+        aktualisieren, ohne hierfür die grafische Benutzeroberfläche zu starten.
       </para>
     </abstract>
+
+    <note>
+      <para>In &app; Version 4.x und früher wurden die separaten Perl-Programme <userinput>gnc-fq-check</userinput>
+        an Stelle von <userinput>gnucash-cli --quote info</userinput> und <userinput>gnc-fq-dump</userinput>
+        anstatt <userinput>gnucash-cli --quote dump</userinput> verwendet.
+      </para>
+    </note>
 
     <sect2 id="fq-check-version">
       <title>Anzeige der &app-fq; Version und der unterstützten Quellen</title>
 
-      <para><userinput>gnucash-cli --quotes info</userinput> erzeugt die folgende Ausgabe:
+      <abstract>
+        <para>Die Nutzung der Option <replaceable>--quotes info</replaceable> liefert die Versionsnummer des derzeit
+          installierten &app-fq; Moduls sowie eine Liste der verfügbaren Quellen. Es informiert Sie
+          auch, wenn es ein Problem mit Ihrer Installation gibt und nennt die Gründe dafür.
+        </para>
+      </abstract>
+
+      <para>Die neueste &app-fq; Version ist &app-fq-vers;. Entsprechend der Aktualität Ihrer Installation kann
+        sich die nachfolgende Auflistung der Quellenmodule unterscheiden.
+      </para>
+
+      <para>Die Eingabe von
+        <cmdsynopsis>
+          <command>gnucash-cli</command>
+          <group choice="req">
+            <arg choice="plain">-Q</arg>
+            <arg choice="plain">--quotes</arg>
+          </group>
+          <arg choice="plain">info</arg>
+        </cmdsynopsis>
+        im Terminal erzeugt die folgende Ausgabe:
       </para>
 
       <informalexample>
@@ -324,12 +339,9 @@ yahoo_json   yahooweb     za
 </screen>
       </informalexample>
 
-      <para>Die neueste &app-fq; Version ist &app-fq-vers;. Entsprechend der Aktualität Ihrer Installation
-        kann sich die hier gemachte Auflistung der Quellenmodule unterscheiden.
-      </para>
-
       <para>Wenn es ein Problem mit Ihrer Installation gibt, werden Sie darauf hingeweisen. In dem nachfolgend
-        aufgeführtem Fall fehlen zum Beispiel die &app-perl;-Module Finance::Quote und JSON::Parse:
+        aufgeführtem Beispiel wird auf Probleme mit den &app-perl;-Modulen Finance::Quote und JSON::Parse
+        hingewiesen:
       </para>
 
       <informalexample>
@@ -347,23 +359,59 @@ Failed to initialize Finance::Quote: missing_modules Finance::Quote JSON::Parse
     </sect2>
 
     <sect2 id="fq-print-quotes">
-      <title>Anzeige von Kursen in einem Terminalfenster</title>
+      <title>Abfrage von Kursen in einem Terminalfenster</title>
+
+      <abstract>
+        <para>Die Option <replaceable>--quotes dump</replaceable> liefert Kursdaten für eine Kursquelle und eine Liste
+          von Symbolen in einem Format, das für Menschen leicht zu lesen ist. Dies ist nützlich,
+          um zu überprüfen, ob eine bestimmte Online-Kursquelle erreichbar ist und Daten liefert.
+        </para>
+
+        <para>Weiterhin können Sie überprüfen, ob das <xref linkend="tool-ge-Symbol" />, welches Sie für Ihr
+          Wertpapier zum Online-Kursabruf verwenden möchten, bei der gewünschten
+          <xref linkend="tool-ge-TypeQuoteSource" /> bekannt ist.
+        </para>
+      </abstract>
+
+      <tip>
+        <para>Sie können <userinput>gnucash-cli --quotes dump</userinput> verwenden, um Kursquellen und Symbole
+          einzeln zu testen, wenn &app; einen Fehler beim Abrufen von Kursen meldet. Der Befehl
+          zeigt die Felder an, die von &app; genutzt werden. Verwenden Sie die Optionen
+          <userinput>gnucash-cli --verbose --quotes dump</userinput>, um alle Informationen zu sehen, die
+          &app-fq; von der Kursquelle erhält.
+        </para>
+      </tip>
 
       <para>Um einen Kurs für eine oder mehrere Aktien oder den Wechselkurs für eine oder mehrere Währungen
-        anzuzeigen, können Sie <userinput>gnucash-cli --quotes dump</userinput> wie folgt
-        verwenden. Es bietet eine Ausgabeform für Devisenkurse und zwei für Aktien und
-        Wertpapiere.
+        anzuzeigen, verwenden Sie den Befehl wie folgt:
+        <cmdsynopsis>
+          <command>gnucash-cli</command>
+          <group choice="req">
+            <arg choice="plain">-Q</arg>
+            <arg choice="plain">--quotes</arg>
+          </group>
+          <arg choice="plain">dump</arg>
+          <group choice="opt">
+            <arg choice="plain">-V</arg>
+            <arg choice="plain">--verbose</arg>
+          </group>
+           <arg choice="plain"><replaceable>Quelle</replaceable></arg>
+           <arg choice="plain" rep="repeat"><replaceable>Symbol</replaceable></arg>
+        </cmdsynopsis>
+      </para>
+
+      <para>Es bietet eine Ausgabeform für Devisenkurse und zwei für Aktien und Wertpapiere.
         <variablelist>
           <varlistentry>
             <term>Währungen</term>
 
             <listitem>
               <para>Für den Abruf von Devisenkursen wird die Quelle <userinput>currency</userinput> verwendet, welche
-                mindestens zwei ISO-4217-Währungscodes erfordern; die Wechselkurse werden in der
-                ersten Währung angegeben.
+                mindestens zwei <ulink url="&url-wp-de;ISO_4217">ISO&nbsp;4217</ulink> Währungscodes erfordern;
+                die Wechselkurse werden in der ersten Währung angegeben.
                 <footnote>
                   <para>Seit &app-fq; 1.41 ist die Standardquelle für Währungen <quote>Alpha Vantage</quote>. Lesen Sie
-                    auch die Hinweise zu <xref linkend="gnc-tbl-fq-currency-source" />.
+                    auch die Hinweise dazu in <xref linkend="gnc-tbl-fq-currency-source" />.
                   </para>
                 </footnote>
                 Zum Beispiel:
@@ -384,13 +432,15 @@ $ gnucash-cli --quotes dump currency USD GBP EUR
             <term>Wertpapiere</term>
 
             <listitem>
-              <itemizedlist>
-                <listitem>
-                  <para>Eine Kurzform, die nur die Felder anzeigt, die &app; benötigt, ergänzt mit Kommentaren, die
-                    angeben, ob die Felder empfohlen oder erforderlich sind; damit können Sie
-                    herausfinden, ob &app; in der Lage sein wird die Kursangaben zu verwenden, um
-                    die Kursdatenbank Ihres Buches zu aktualisieren.
-                    <informalexample>
+              <para>Zum Abruf von Kursen Ihrer Wertpapiere ist die abzufragende Kursquelle sowie das gewünschte Symbol
+                anzugeben.
+                <itemizedlist>
+                  <listitem>
+                    <para>Eine Kurzform, die nur die Felder anzeigt, die &app; benötigt, ergänzt mit Kommentaren, die
+                      angeben, ob die Felder empfohlen oder erforderlich sind; damit können Sie
+                      herausfinden, ob &app; in der Lage sein wird die Kursangaben zu verwenden, um
+                      die Kursdatenbank Ihres Buches zu aktualisieren.
+                      <informalexample>
 <?dbfo pgwide="1"?>
 <screen language="console">
 $ gnucash-cli --quotes dump yahooweb AAPL
@@ -401,18 +451,18 @@ $ gnucash-cli --quotes dump yahooweb AAPL
        NAV:                 &lt;=== Eins von diesen
      Preis:                 &lt;=/ 
 </screen>
-                    </informalexample>
-                  </para>
-                </listitem>
+                      </informalexample>
+                    </para>
+                  </listitem>
 
-                <listitem>
-                  <para>Mit der Option <userinput>-V</userinput> wird eine möglicherweise längere Ausgabe mit allen
-                    Datenfeldern von &app-fq; zurückgegeben. Dies kann nützlich sein, um Probleme
-                    mit einem &app-fq; Quellmodul zu beheben.
-                    <informalexample>
+                  <listitem>
+                    <para>Mit der Option <userinput>--verbose</userinput> wird eine längere Ausgabe mit allen Datenfeldern von
+                      &app-fq; zurückgegeben. Dies kann nützlich sein, um Probleme mit einem
+                      &app-fq; Quellmodul zu beheben.
+                      <informalexample>
 <?dbfo pgwide="1"?>
 <screen language="console">
-$ ALPHAVANTAGE_API_KEY=123456789 bin/gnucash-cli -V --quotes dump alphavantage INTC
+$ ALPHAVANTAGE_API_KEY=123456789 gnucash-cli --verbose --quotes dump alphavantage INTC
 INTC:
         date =&gt; 07/27/2023
        close =&gt; 34.3600
@@ -430,31 +480,60 @@ currency_set_by_fq =&gt; 1
          net =&gt; 0.1900
       method =&gt; alphavantage
 </screen>
-                    </informalexample>
+                      </informalexample>
 
-                    <note>
-                      <para>Beachten Sie, dass wir in diesem Fall als Quelle alphavantage verwendet und den
-                        <userinput>ALPHAVANTAGE_API_KEY</userinput> in der Befehlszeile angegeben
-                        haben. Das ist nicht notwendig, wenn der Schlüssel bereits in der
-                        Umgebungsvariable der Shell oder in den &app;-Einstellungen gespeichert ist.
-                      </para>
-                    </note>
-                  </para>
-                </listitem>
-              </itemizedlist>
+                      <note>
+                        <para>Beachten Sie, dass wir in diesem Fall als Quelle alphavantage verwendet und den
+                          <userinput>ALPHAVANTAGE_API_KEY</userinput> in der Befehlszeile angegeben
+                          haben. Das ist nicht notwendig, wenn der Schlüssel bereits in &mc.ed.pref;
+                          <xref linkend="prefs-online-quotes" /> gespeichert ist.
+                        </para>
+                      </note>
+                    </para>
+                  </listitem>
+                </itemizedlist>
+              </para>
             </listitem>
           </varlistentry>
         </variablelist>
       </para>
+
+      <procedure>
+        <para>Um zu testen, ob &app-fq; für Währungen innerhalb von &app; funktioniert, gehen Sie wie folgt vor:
+        </para>
+
+        <step>
+          <para>erstellen Sie eine Buchung mit dem gewünschtem Handelsgut in der Buchwährung,
+          </para>
+        </step>
+
+        <step>
+          <para>machen einen Rechtsklick darauf,
+          </para>
+        </step>
+
+        <step>
+          <para>wählen Sie im Kontextmenü die Option &gmi.ac.ed-ex;.
+          </para>
+        </step>
+
+        <step>
+          <para>Klicken Sie auf die Schaltfläche <guilabel>Wechselkurs abrufen</guilabel> im <xref linkend="trans-win-enter" />.
+          </para>
+        </step>
+      </procedure>
+
+      <para>Sind die Kursquelle sowie das Symbol richtig eingestellt, wird der aktuelle Kurs in das Feld für den Wechselkurs eingetragen.
+      </para>
     </sect2>
 
     <sect2 id="fq-auto-quote">
-      <title>Automatisierte Abfrage von Kursen mit &app-cli;</title>
+      <title>Automatisierte Aktualisierung von Kursen mit &app-cli;</title>
 
       <para>Mit dem Kommando <command>gnucash-cli --quotes get &user-datafile;</command>
         <footnote>
-          <simpara>Der alte Befehl <command>gnucash --add-price-quotes &user-datafile;</command> ist seit &app; 5.0
-            nicht mehr verfügbar!
+          <simpara>Dies ersetzt den Befehl <userinput>&app; --add-price-quotes &user-datafile;</userinput> in &app;
+            Version 4.x und früher.
           </simpara>
         </footnote>
         können Sie die aktuellen Kurse Ihrer Devisen und Wertpapiere abrufen und direkt in ihre
@@ -519,8 +598,8 @@ currency_set_by_fq =&gt; 1
 gnucash-cli --quotes get &user-datafile; &gt; /dev/null 2&gt;&amp;1
 </screen>
                   </informalexample>
-                  (Den Zeilenumbruch nicht in die crontab übernehmen, der wurde hier nur zum
-                  Zwecke der Lesbarkeit eingefügt.)
+                  (Den Zeilenumbruch nicht in die crontab übernehmen, der wurde hier nur zum Zwecke
+                  der Lesbarkeit eingefügt.)
                 </para>
               </important>
             </para>

--- a/de/manual/ch_Tools_Assistants.xml
+++ b/de/manual/ch_Tools_Assistants.xml
@@ -6096,7 +6096,7 @@ and update the appendix. -->
                     <para>Nachdem Sie die Art der Quelle für Kursangebote ausgewählt haben, wählen Sie eine Datenquelle aus
                       dem Pulldown-Menü. Die zur Verfügung stehenden Datenquellen sind abhängig
                       von der installierten Version von &app-fq; und werden Ihnen bei Verwendung des
-                      Befehls <command>gnc-fq-check</command> angezeigt. Details zu den derzeit
+                      Befehls <userinput>gnucash-cli --quotes info</userinput> angezeigt. Details zu den derzeit
                       unterstützten Datenquellen finden Sie unter
                       <xref linkend="fq-sources"></xref>.
                       <note>

--- a/de/manual/tips-appendix.xml
+++ b/de/manual/tips-appendix.xml
@@ -37,7 +37,7 @@
   </abstract>
 
   <sect1 id="fq-sources">
-    <title>Die Datenquellen in Finance::Quote</title>
+    <title>Datenquellen in Finance::Quote</title>
 
     <para>Es gibt drei Arten von Quellen. Dabei ist die erste - Währung - fest implementiert und dafür
       zuständig, die Wechselkurse der von der ISO registrierten Währungen abzurufen. Die beiden
@@ -144,24 +144,7 @@
                     </listitem>
 
                     <listitem>
-                      <para>Ihren dort erhaltenen Schlüssel in
-<!-- Fixme: unwritten: <link linkend="prefs-online-quotes"> / -->
-                        &mc.ed.pref; <guilabel>Online Kurse</guilabel>
-<!-- Fixme: unwritten: </link> / -->
-                        eingeben.
-                      </para>
-                    </listitem>
-
-                    <listitem>
-                      <para>Um ihn auch mit dem <command>gnucash-cli --quotes dump</command> Befehl zu verwenden,
-                        müssen Sie ihn auch in einer <emphasis>Umgebungsvariable</emphasis>
-                        <envar>ALPHAVANTAGE_API_KEY</envar> setzen. Ziehen Sie dazu die
-                        Dokumentation Ihres Betriebssystems oder Befehlszeileninterpreters zu Rate,
-                        wie Sie das dauerhaft erreichen.
-                        <example>
-                          <title>Umgebungsvariable in <filename>.bashrc</filename></title>
-<programlisting language="bash">export ALPHAVANTAGE_API_KEY=<replaceable>##############</replaceable></programlisting>
-                        </example>
+                      <para>Ihren dort erhaltenen Schlüssel in &mc.ed.pref; <xref linkend="prefs-online-quotes" /> eintragen.
                       </para>
                     </listitem>
                   </orderedlist>

--- a/de/manual/tips-appendix.xml
+++ b/de/manual/tips-appendix.xml
@@ -153,7 +153,7 @@
                     </listitem>
 
                     <listitem>
-                      <para>Um ihn auch mit <command>gnc-fq-<replaceable>*</replaceable></command> Befehlen zu verwenden,
+                      <para>Um ihn auch mit dem <command>gnucash-cli --quotes dump</command> Befehl zu verwenden,
                         müssen Sie ihn auch in einer <emphasis>Umgebungsvariable</emphasis>
                         <envar>ALPHAVANTAGE_API_KEY</envar> setzen. Ziehen Sie dazu die
                         Dokumentation Ihres Betriebssystems oder Befehlszeileninterpreters zu Rate,

--- a/ru/guide/ch_invest.xml
+++ b/ru/guide/ch_invest.xml
@@ -3233,7 +3233,7 @@ Income
         </figure>
 
         <para>Refer to the Help Manual, Chapter 8 Tools &amp; Assistants,
-          <ulink url="&url-docs-C;help/tool-lots.html">Lots in Account</ulink> for details of the
+          <ulink url="&url-docs-C;manual/tool-lots.html">Lots in Account</ulink> for details of the
           Lots in Account screen elements.
         </para>
       </sect3>


### PR DESCRIPTION
- replace 'help' by 'manual' in links
- remove section 'F::Q install' from Guide and insert link into Manual instead 
- add a note for the removed 'gnc-fq-*' scripts
- describe the purpose of the 'info' and 'dump' functions