### PR TITLE
Update ch_oview.xml - Fix typo "are are"

### DIFF
--- a/C/guide/ch_oview.xml
+++ b/C/guide/ch_oview.xml
@@ -220,7 +220,7 @@
       <itemizedlist>
         <listitem>
           <para><emphasis>Native Languages</emphasis>: &app; has been translated into over 55 languages. Full
-            translated are are Chinese (traditional), Croatian, Dutch, Hebrew, Italian, Portuguese,
+            translated are Chinese (traditional), Croatian, Dutch, Hebrew, Italian, Portuguese,
             and Ukrainian. Almost as good, with over 90% translated, are Catalan, Chinese
             (simplified), German, Indonesian, Japanese, Portuguese (Brazil), and Spanish.
 <!-- Latvian, Serbian, Russian, Turkish -->


### PR DESCRIPTION
I started reading the manual and this typo jumped into my view.