### PR TITLE
Update Appendix A for finance-quote 1.63

### DIFF
--- a/C/manual/tips-appendix.docbook
+++ b/C/manual/tips-appendix.docbook
@@ -152,23 +152,24 @@
                 </entry>
 
                 <entry>
-                  <para>You need to
-                    <orderedlist spacing="compact">
-                      <listitem>
-                        <para>register at <ulink url="&url-av;"/> and
+                  <important>
+                    <title>API Key Required</title>
+                    <procedure>
+                      <step>
+                        <para>Register at <ulink url="&url-av;"/> and
                           <important>
                             <para>Watch the restrictions of the Free API Key in their FAQ!
                             </para>
                           </important>
                         </para>
-                      </listitem>
+                      </step>
 
-                      <listitem>
-                        <para>store the key which you got there in &mc.ed.pref; <xref linkend="prefs-online-quotes" />.
+                      <step>
+                        <para>Store the key which you got there in &mc.ed.pref; <xref linkend="prefs-online-quotes" />.
                         </para>
-                      </listitem>
-                    </orderedlist>
-                  </para>
+                      </step>
+                    </procedure>
+                  </important>
                 </entry>
               </row>
 
@@ -497,23 +498,24 @@
                 </entry>
 
                 <entry>
-                  <para>You need to
-                    <orderedlist spacing="compact">
-                      <listitem>
-                        <para>register at <ulink url="https://iexcloud.io"/> and
+                  <important>
+                    <title>API Key Required</title>
+                    <procedure>
+                      <step>
+                        <para>Register at <ulink url="https://iexcloud.io"/> and
                           <important>
                             <para>Watch the restrictions of the Free API Key in their pricing info!
                             </para>
                           </important>
                         </para>
-                      </listitem>
+                      </step>
 
-                      <listitem>
+                      <step>
                         <para>Export the key as <envar>IEXCLOUD_API_KEY</envar> environment variable before starting &appname;.
                         </para>
-                      </listitem>
-                    </orderedlist>
-                  </para>
+                      </step>
+                    </procedure>
+                  </important>
                 </entry>
               </row>
 
@@ -754,23 +756,24 @@
                 </entry>
 
                 <entry>
-                  <para>You need to
-                    <orderedlist spacing="compact">
-                      <listitem>
-                        <para>register at <ulink url="https://www.stockdata.org"/> and
+                  <important>
+                    <title>API Key Required</title>
+                    <procedure>
+                      <step>
+                        <para>Register at <ulink url="https://www.stockdata.org"/> and
                           <important>
                             <para>Watch the restrictions of the Free API Key in their pricing info!
                             </para>
                           </important>
                         </para>
-                      </listitem>
+                      </step>
 
-                      <listitem>
+                      <step>
                         <para>Export the key as <envar>STOCKDATA_API_KEY</envar> environment variable before starting &appname;.
                         </para>
-                      </listitem>
-                    </orderedlist>
-                  </para>
+                      </step>
+                    </procedure>
+                  </important>
                 </entry>
               </row>
 
@@ -905,23 +908,24 @@
                 </entry>
 
                 <entry>
-                  <para>You need to
-                    <orderedlist spacing="compact">
-                      <listitem>
-                        <para>register at <ulink url="https://twelvedata.com"/> and
+                  <important>
+                    <title>API Key Required</title>
+                    <procedure>
+                      <step>
+                        <para>Register at <ulink url="https://twelvedata.com"/> and
                           <important>
                             <para>Watch the restrictions of the Free API Key in their pricing info!
                             </para>
                           </important>
                         </para>
-                      </listitem>
+                      </step>
 
-                      <listitem>
+                      <step>
                         <para>Export the key as <envar>TWELVEDATA_API_KEY</envar> environment variable before starting &appname;.
                         </para>
-                      </listitem>
-                    </orderedlist>
-                  </para>
+                      </step>
+                    </procedure>
+                  </important>
                 </entry>
               </row>
 
@@ -1022,25 +1026,24 @@
                 </entry>
 
                 <entry>
-                  <para>You need to
-                    <orderedlist spacing="compact">
-                      <listitem>
-                        <para>register at <ulink url="https://financeapi.net"/> and
+                  <important>
+                    <title>API Key Required</title>
+                    <procedure>
+                      <step>
+                        <para>Register at <ulink url="https://financeapi.net"/> and
                           <important>
                             <para>Watch the restrictions of the Free API Key in their pricing info!
                             </para>
                           </important>
                         </para>
-                      </listitem>
+                      </step>
 
-                      <listitem>
-                        <para>store the key which you got there in &mc.ed.pref; <xref linkend="prefs-online-quotes" />.
+                      <step>
+                        <para>Store the key which you got there in &mc.ed.pref; <xref linkend="prefs-online-quotes" />.
                         </para>
-                      </listitem>
-                    </orderedlist>
-                  </para>
-                  <para>
-                  </para>
+                      </step>
+                    </procedure>
+                  </important>
                 </entry>
               </row>
 

--- a/C/manual/tips-appendix.docbook
+++ b/C/manual/tips-appendix.docbook
@@ -720,6 +720,7 @@
                 <entry>
                   <para><ulink url="https://www.six-group.com"/>
                   </para>
+                  <para>includes former sources sixfunds and sixshares</para>
                 </entry>
               </row>
 

--- a/C/manual/tips-appendix.docbook
+++ b/C/manual/tips-appendix.docbook
@@ -1655,73 +1655,73 @@
             <tbody>
               <row>
                 <entry>
-                  Australia (ASX, ...)
+                  Australia (ASX)
                 </entry>
               </row>
 
               <row>
                 <entry>
-                  Canada (AlphaVantage, TMX, ...)
+                  Canada (AlphaVantage, TMX)
                 </entry>
               </row>
 
               <row>
                 <entry>
-                  Dutch (AEX, ...)
+                  Dutch (AEX)
                 </entry>
               </row>
 
               <row>
                 <entry>
-                  Europe (ASEGR, Bourso, BVB, Consorsbank, Sinvestor, Stooq, Tradegate, XETRA, ...)
+                  Europe (ASEGR, Bourso, BVB, Consorsbank, Sinvestor, Stooq, Tradegate, XETRA)
                 </entry>
               </row>
 
               <row>
                 <entry>
-                  France (Bourso, ...)
+                  France (Bourso)
                 </entry>
               </row>
 
               <row>
                 <entry>
-                  Greece (ASEGR, ...)
+                  Greece (ASEGR)
                 </entry>
               </row>
 
               <row>
                 <entry>
-                  India Mutual (AMFI, ...)
+                  India Mutual (AMFI)
                 </entry>
               </row>
 
               <row>
                 <entry>
-                  Nasdaq (AlphaVantage, FinanceAPI, Fool, GoogleWeb, IEXCloud, MarketWatch, StockData, YahooJSON, ...)
+                  Nasdaq (AlphaVantage, FinanceAPI, Fool, GoogleWeb, IEXCloud, MarketWatch, StockData, YahooJSON)
                 </entry>
               </row>
 
               <row>
                 <entry>
-                  NYSE (AlphaVantage, FinanceAPI, Fool, GoogleWeb, IEXCloud, MarketWatch, StockData, YahooJSON, ...)
+                  NYSE (AlphaVantage, FinanceAPI, Fool, GoogleWeb, IEXCloud, MarketWatch, StockData, YahooJSON)
                 </entry>
               </row>
 
               <row>
                 <entry>
-                  Poland (Stooq, ...)
+                  Poland (Stooq)
                 </entry>
               </row>
 
               <row>
                 <entry>
-                  Romania (BVB, ...)
+                  Romania (BVB)
                 </entry>
               </row>
 
               <row>
                 <entry>
-                  South Africa (Sharenet, ...)
+                  South Africa (Sharenet)
                 </entry>
               </row>
 
@@ -1733,13 +1733,13 @@
 
               <row>
                 <entry>
-                  U.K. Funds (FTfunds, MorningStarUK, ...)
+                  U.K. Funds (FTfunds, MorningStarUK)
                 </entry>
               </row>
 
               <row>
                 <entry>
-                  USA (AlphaVantage, FinanceAPI, Fool, IEXCloud, YahooJSON, ...)
+                  USA (AlphaVantage, FinanceAPI, Fool, IEXCloud, YahooJSON)
                 </entry>
               </row>
             </tbody>

--- a/C/manual/tips-appendix.docbook
+++ b/C/manual/tips-appendix.docbook
@@ -1176,10 +1176,7 @@
                 </entry>
 
                 <entry>
-                  <para><ulink url="https://www.cominvest-am.de"/>
-                  </para>
-
-                  <para>Obsolete, update: <ulink url="https://eggert.org/software/Comdirect.pm"/>
+                  <para>The Commerzbank AG changed their structure, use their brand <emphasis>comdirect</emphasis> now.
                   </para>
                 </entry>
               </row>

--- a/C/manual/tips-appendix.docbook
+++ b/C/manual/tips-appendix.docbook
@@ -1387,7 +1387,7 @@
                 </entry>
 
                 <entry>
-                  <para><ulink url="https://www.six-swiss-exchange.com"/>
+                  <para>Part of <ulink url="https://www.six-group.com"/>
                   </para>
                 </entry>
               </row>
@@ -1404,7 +1404,7 @@
                 </entry>
 
                 <entry>
-                  <para><ulink url="https://www.six-swiss-exchange.com"/>
+                  <para>Part of <ulink url="https://www.six-group.com"/>
                   </para>
                 </entry>
               </row>

--- a/C/manual/tips-appendix.docbook
+++ b/C/manual/tips-appendix.docbook
@@ -815,7 +815,7 @@
                 </entry>
 
                 <entry>
-                  <para>torouro_direto
+                  <para>tesouro_direto
                   </para>
                 </entry>
 

--- a/C/manual/tips-appendix.docbook
+++ b/C/manual/tips-appendix.docbook
@@ -40,7 +40,7 @@
 
   <sect1 id="fq-sources">
     <title>Finance::Quote Sources</title>
-    <para>Please also consult <link linkend='fq-deprecated-sources'>Deprecated Finance::Quote Sources</link> for a list of deprecated sources.
+    <para>Please also consult <link linkend='fq-obsolete-sources'>Obsolete Finance::Quote Sources</link> for a list of obsolete sources.
     </para>
 
     <para>There are 3 types of sources of which the first - currency - is hardcoded and responsible to fetch
@@ -6316,18 +6316,18 @@ bogus_symbol2,price2,date2
       <ulink url="https://rt.cpan.org/Ticket/Attachment/1121440/589997/Tiaacref.pm.zip"/>
     </para>
   </sect1>
-  <sect1 id="fq-deprecated-sources">
-    <title>Deprecated Finance::Quote Sources</title>
+  <sect1 id="fq-obsolete-sources">
+    <title>Obsolete Finance::Quote Sources</title>
 
     <para>This section provides information about sources that used to be provided by <application>Finance::Quote</application>
       but have already been removed or have been not functioning correctly.
     </para>
 
-    <sect2 id="fq-deprecated-sources-single">
-      <title>Deprecated Quote Sources - Individual sources</title>
+    <sect2 id="fq-obsolete-sources-single">
+      <title>Obsolete Quote Sources - Individual sources</title>
 
-      <table frame="topbot" id="gnc-tbl-fq-deprecated-individual-source">
-        <title>Deprecated individual sources for quotes</title>
+      <table frame="topbot" id="gnc-tbl-fq-obsolete-individual-source">
+        <title>Obsolete individual sources for quotes</title>
 
         <tgroup cols="3">
           <thead>
@@ -6903,11 +6903,11 @@ bogus_symbol2,price2,date2
       </table>
     </sect2>
 
-    <sect2 id="fq-deprecated-sources-multiple">
-      <title>Deprecated Finance::Quote Sources - Multiple sources</title>
+    <sect2 id="fq-obsolete-sources-multiple">
+      <title>Obsolete Finance::Quote Sources - Multiple sources</title>
 
-      <table frame="topbot" id="gnc-tbl-fq-deprecated-multiple-source">
-        <title>Deprecated Multiple sources for quotes</title>
+      <table frame="topbot" id="gnc-tbl-fq-obsolete-multiple-source">
+        <title>Obsolete Multiple sources for quotes</title>
 
         <tgroup cols="1">
           <thead>

--- a/C/manual/tips-appendix.docbook
+++ b/C/manual/tips-appendix.docbook
@@ -38,15 +38,13 @@
       nature of gathering finance quotes (web scrapping, unstable API) the list of quote sources is constantly evolving.
     </para>
 
-    <para>Some modules are considered Active, that means it should be possible to fetch quotes using them. Please
-    see <link linkend='fq-active-sources-single'>Active Individual Quote Sources</link>
-    and <link linkend='fq-active-sources-multiple'>Active Multiple Quote Sources</link> for detailed lists.
+    <para>Some modules are considered Active, that means it should be possible to fetch quotes using them. Please see
+    <xref linkend='fq-active-sources-single'/> and <xref linkend='fq-active-sources-multiple'/> for detailed lists.
     </para>
 
     <para>Some sources may be considered obsolete that means that support for them has been removed (or is being
-    removed), or they are not functioning correctly. Please see <link linkend='fq-obsolete-sources-single'>Obsolete
-    Single Quote Sources</link> and <link linkend='fq-obsolete-sources-multiple'>Obsolete Multiple Quote Sources</link>
-    for detailed list.
+    removed), or they are not functioning correctly. Please see <xref linkend='fq-obsolete-sources-single'/> and <xref
+    linkend='fq-obsolete-sources-multiple'/> for detailed list.
     </para>
 
     <para>If a particular source is the only place where the quote can be obtained but it's been failing or is obsolete,

--- a/C/manual/tips-appendix.docbook
+++ b/C/manual/tips-appendix.docbook
@@ -51,7 +51,7 @@
 
     <para>If a particular source is the only place where the quote can be obtained but it's been failing or is obsolete,
     please reach out to <application>Finance::Quote</application> maintainers at
-    <ulink url="https://github.com/finance-quote/finance-quote"/>.
+    <ulink url="&url-fq;"/>.
     </para>
   </abstract>
 

--- a/C/manual/tips-appendix.docbook
+++ b/C/manual/tips-appendix.docbook
@@ -1815,10 +1815,13 @@
             </tbody>
           </tgroup>
         </table>
-        <para>Sources: src/engine/gnc-commodity.c:gnc_quote_source (commit c0fd3b3, which was adjusted for
-        Finance::Quote 1.63), <ulink url="&url-wiki;">&appname;-Wiki</ulink>,
-        <ulink url="&url-bug-start;page.cgi?id=browse.html&amp;product=GnuCash">bugzilla</ulink>,
-        <ulink url="&url-wiki-ml;#Mailing_List_Archives">mailing list archive</ulink>.
+        <para>Sources: libgnucash/engine/gnc-commodity.cpp <ulink
+        url="https://github.com/Gnucash/gnucash/pull/2033">Adjusted for
+        Finance::Quote 1.63</ulink>, <ulink
+        url="&url-wiki;">&appname;-Wiki</ulink>, <ulink
+        url="&url-bug-start;page.cgi?id=browse.html&amp;product=GnuCash">bugzilla</ulink>,
+        <ulink url="&url-wiki-ml;#Mailing_List_Archives">mailing list
+        archive</ulink>.
       </para>
       </sect3>
     </sect2>

--- a/C/manual/tips-appendix.docbook
+++ b/C/manual/tips-appendix.docbook
@@ -300,6 +300,23 @@
 
             <row>
               <entry>
+                <para>Colombo Stock Exchange, LK
+                </para>
+              </entry>
+
+              <entry>
+                <para>cse
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.cse.lk"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
                 <para>comdirect, DE
                 </para>
               </entry>
@@ -6414,23 +6431,6 @@ bogus_symbol2,price2,date2
 
               <entry>
                 <para><ulink url="https://citywire.co.uk"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Colombo Stock Exchange, LK
-                </para>
-              </entry>
-
-              <entry>
-                <para>cse
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.cse.lk"/>
                 </para>
               </entry>
             </row>

--- a/C/manual/tips-appendix.docbook
+++ b/C/manual/tips-appendix.docbook
@@ -23,7 +23,8 @@
 <appendix id="tips">
   <appendixinfo>
     <releaseinfo>
-      &appname; Version 2.6.20 + Finance::Quote Version 1.47, March 2018
+      &appname; Version 5.9 + Finance::Quote Version 1.63, October 2024
+<!-- Version 2.6.20 + Finance::Quote Version 1.47, March 2018 -->
 <!-- Version 2.6.11 + Finance::Quote Version 1.38, February 2016, FEll -->
 <!-- Version 2.4.11 + Finance::Quote Version 1.18, April 2013, FEll -->
 <!-- Version 1.0, December 2006 -->
@@ -39,6 +40,8 @@
 
   <sect1 id="fq-sources">
     <title>Finance::Quote Sources</title>
+    <para>Please also consult <link linkend='fq-deprecated-sources'>Deprecated Finance::Quote Sources</link> for a list of deprecated sources.
+    </para>
 
     <para>There are 3 types of sources of which the first - currency - is hardcoded and responsible to fetch
       ISO currencies. The other two can be selected in the security editor.
@@ -84,7 +87,7 @@
 
               <entry>
                 <para>End of 2017 the provider changed. Make sure, you updated F::Q to at least version 1.47 and follow
-                  the instructions at Alphavantage below.
+                  the instructions at AlphaVantage below.
                 </para>
               </entry>
             </row>
@@ -122,7 +125,7 @@
           <tbody valign='middle'>
             <row>
               <entry>
-                <para>Alphavantage, US
+                <para>AlphaVantage, US
                 </para>
               </entry>
 
@@ -164,27 +167,10 @@
               </entry>
 
               <entry>
-                <para><ulink url="https://www.aex.nl"/>
+                <para><ulink url="https://live.euronext.com"/>
                 </para>
 
                 <para>includes former sources AEX-<quote>Futures</quote> and -<quote>Options</quote>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>American International Assurance, HK
-                </para>
-              </entry>
-
-              <entry>
-                <para>aiahk
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.aia.com.hk"/>
                 </para>
               </entry>
             </row>
@@ -218,7 +204,7 @@
               </entry>
 
               <entry>
-                <para><ulink url="https://www.ase.gr"/>
+                <para><ulink url="https://www.athexgroup.gr"/>
                 </para>
               </entry>
             </row>
@@ -246,34 +232,51 @@
 
             <row>
               <entry>
-                <para>BAMOSZ funds, HU
+                <para>Bloomberg
                 </para>
               </entry>
 
               <entry>
-                <para>bamosz
+                <para>bloomberg
                 </para>
               </entry>
 
               <entry>
-                <para><ulink url="https://www.bamosz.hu"/>
+                <para><ulink url="https://www.bloomberg.com"/>
                 </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                <para>BMO NesbittBurns, CA
+                <para>Borsa Italiana, IT
                 </para>
               </entry>
 
               <entry>
-                <para>bmonesbittburns
+                <para>borsa_italiana
                 </para>
               </entry>
 
               <entry>
-                <para><ulink url="https://bmonesbittburns.com"/>
+                <para><ulink url="https://www.borsaitaliana.it"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>BSE India (formerly known as Bombay Stock Exchange Ltd.), IN
+                </para>
+              </entry>
+
+              <entry>
+                <para>bseindia
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.bseindia.com"/>
                 </para>
               </entry>
             </row>
@@ -285,7 +288,7 @@
               </entry>
 
               <entry>
-                <para>bsero
+                <para>bvb or tradeville
                 </para>
               </entry>
 
@@ -297,71 +300,34 @@
 
             <row>
               <entry>
-                <para>Budapest Stock Exchange (BET), ex-BUX, HU
+                <para>comdirect, DE
                 </para>
               </entry>
 
               <entry>
-                <para>bse or bet
+                <para>comdirect
                 </para>
               </entry>
 
               <entry>
-                <para><ulink url="https://www.bet.hu"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Citywire Funds, GB
-                </para>
-              </entry>
-
-              <entry>
-                <para>citywire
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://citywire.co.uk"/>
+                <para><ulink url="https://www.comdirect.de"/>
                 </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                <para>Colombo Stock Exchange, LK
+                <para>Consors Bank, DE
                 </para>
               </entry>
 
               <entry>
-                <para>cse
+                <para>consorsbank
                 </para>
               </entry>
 
               <entry>
-                <para><ulink url="https://www.cse.lk"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Cominvest Asset Management, ex-Adig, DE
-                </para>
-              </entry>
-
-              <entry>
-                <para>cominvest
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.cominvest-am.de"/>
-                </para>
-
-                <para>Obsolete, update: <ulink url="https://eggert.org/software/Comdirect.pm"/>
+                <para><ulink url="https://www.consorsbank.de"/>
                 </para>
               </entry>
             </row>
@@ -402,74 +368,6 @@
 
             <row>
               <entry>
-                <para>Equinox Unit Trusts, ZA
-                </para>
-              </entry>
-
-              <entry>
-                <para>za_unittrusts
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.equinox.co.za"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Fidelity Investments, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>fidelity_direct
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.fidelity.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Fidelity Fixed, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>fidelityfixed
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.fidelity.com/fixed-income-bonds/overview"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Finance Canada
-                </para>
-              </entry>
-
-              <entry>
-                <para>financecanada
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://finance.canada.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
                 <para>Financial Times Funds service, GB
                 </para>
               </entry>
@@ -504,47 +402,24 @@
 
             <row>
               <entry>
-                <para>First Trust Portfolios, US
+                <para>FondsWeb, DE
                 </para>
               </entry>
 
               <entry>
-                <para>ftportfolios_direct
+                <para>fondsweb
                 </para>
               </entry>
 
               <entry>
-                <para><ulink url="https://www.ftportfolios.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Fund Library, CA
-                </para>
-              </entry>
-
-              <entry>
-                <para>fundlibrary
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.fundlibrary.com"/>
-                </para>
-
-                <para>This module uses an id that represents the mutual fund on
-                  <ulink url="https://www.fundlibrary.com"/>. There is no easy way of fetching the
-                  id except to jump onto the fundlibrary website, look up the fund and view the url
-                  for clues to its id number.
+                <para><ulink url="https://www.fondsweb.com"/>
                 </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                <para>GoldMoney spot rates, JE
+                <para>GoldMoney precious metals
                 </para>
               </entry>
 
@@ -561,34 +436,83 @@
 
             <row>
               <entry>
-                <para>HElsinki stock eXchange, FI
+                <para>Google Web, US Stocks
                 </para>
               </entry>
 
               <entry>
-                <para>hex
+                <para>googleweb or bats
                 </para>
               </entry>
 
               <entry>
-                <para><ulink url="https://www.hex.com"/>
+                <para><ulink url="https://www.google.com/finance"/>
                 </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                <para>Man Investments, AU
+                <para>IEX (Investors Exchange), US
                 </para>
               </entry>
 
               <entry>
-                <para>maninv
+                <para>iexcloud
                 </para>
               </entry>
 
               <entry>
-                <para><ulink url="https://www.maninvestments.com.au"/>
+                <para>You need to
+                  <orderedlist spacing="compact">
+                    <listitem>
+                      <para>register at <ulink url="https://iexcloud.io"/> and
+                        <important>
+                          <para>Watch the restrictions of the Free API Key in their pricing info!
+                          </para>
+                        </important>
+                      </para>
+                    </listitem>
+
+                    <listitem>
+                      <para>Export the key as <envar>IEXCLOUD_API_KEY</envar> environment variable before starting &appname;.
+                      </para>
+                    </listitem>
+                  </orderedlist>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>MarketWatch
+                </para>
+              </entry>
+
+              <entry>
+                <para>marketwatch
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.marketwatch.com"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Morningstar, CH
+                </para>
+              </entry>
+
+              <entry>
+                <para>morningstarch
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.morningstar.ch"/>
                 </para>
               </entry>
             </row>
@@ -600,7 +524,7 @@
               </entry>
 
               <entry>
-                <para>mstaruk
+                <para>morningstaruk or mstaruk
                 </para>
               </entry>
 
@@ -623,23 +547,6 @@
 
               <entry>
                 <para><ulink url="https://www.morningstar.co.jp"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Morningstar, SE
-                </para>
-              </entry>
-
-              <entry>
-                <para>morningstar
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.morningstar.se"/>
                 </para>
               </entry>
             </row>
@@ -680,6 +587,40 @@
 
             <row>
               <entry>
+                <para>NSE (National Stock Exchange), IN
+                </para>
+              </entry>
+
+              <entry>
+                <para>nseindia
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.nseindia.com"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>OnVista, DE
+                </para>
+              </entry>
+
+              <entry>
+                <para>onvista
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.onvista.de"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
                 <para>Paris Stock Exchange/Boursorama, FR
                 </para>
               </entry>
@@ -697,68 +638,51 @@
 
             <row>
               <entry>
-                <para>Paris Stock Exchange/LeRevenu, FR
+                <para>S-Investor, DE
                 </para>
               </entry>
 
               <entry>
-                <para>lerevenu
+                <para>sinvestor
                 </para>
               </entry>
 
               <entry>
-                <para><ulink url="https://bourse.lerevenu.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Platinum Asset Management, AU
-                </para>
-              </entry>
-
-              <entry>
-                <para>platinum
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.platinum.com.au"/>
+                <para><ulink url="https://web.s-investor.de"/>
                 </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                <para>SIX Swiss Exchange Funds, CH
+                <para>Sharenet, ZA
                 </para>
               </entry>
 
               <entry>
-                <para>sixfunds
+                <para>za
                 </para>
               </entry>
 
               <entry>
-                <para><ulink url="https://www.six-swiss-exchange.com"/>
+                <para><ulink url="https://www.sharenet.co.za"/>
                 </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                <para>SIX Swiss Exchange Shares, CH
+                <para>SIX Swiss Exchange, CH
                 </para>
               </entry>
 
               <entry>
-                <para>sixshares
+                <para>six
                 </para>
               </entry>
 
               <entry>
-                <para><ulink url="https://www.six-swiss-exchange.com"/>
+                <para><ulink url="https://www.six-group.com"/>
                 </para>
               </entry>
             </row>
@@ -786,68 +710,83 @@
 
             <row>
               <entry>
-                <para>Sharenet, ZA
+                <para>StockData
                 </para>
               </entry>
 
               <entry>
-                <para>za
+                <para>stockdata
                 </para>
               </entry>
 
               <entry>
-                <para><ulink url="https://www.sharenet.co.za"/>
-                </para>
-              </entry>
-            </row>
+                <para>You need to
+                  <orderedlist spacing="compact">
+                    <listitem>
+                      <para>register at <ulink url="https://www.stockdata.org"/> and
+                        <important>
+                          <para>Watch the restrictions of the Free API Key in their pricing info!
+                          </para>
+                        </important>
+                      </para>
+                    </listitem>
 
-            <row>
-              <entry>
-                <para>StockHouse Canada, CA
-                </para>
-              </entry>
-
-              <entry>
-                <para>stockhousecanada_fund
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.stockhouse.ca"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>TD Waterhouse Funds, CA
-                </para>
-              </entry>
-
-              <entry>
-                <para>tdwaterhouse
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.tdassetmanagement.com"/>
+                    <listitem>
+                      <para>Export the key as <envar>STOCKDATA_API_KEY</envar> environment variable before starting &appname;.
+                      </para>
+                    </listitem>
+                  </orderedlist>
                 </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                <para>TD Efunds, CA
+                <para>Stooq, PL
                 </para>
               </entry>
 
               <entry>
-                <para>tdefunds
+                <para>stooq
                 </para>
               </entry>
 
               <entry>
-                <para><ulink url="https://www.tdwaterhouse.ca"/>
+                <para><ulink url="https://stooq.com"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>T. Rowe Price, US
+                </para>
+              </entry>
+
+              <entry>
+                <para>troweprice or troweprice_direct
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.troweprice.com"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Tesouro Direto bonds, BR
+                </para>
+              </entry>
+
+              <entry>
+                <para>torouro_direto
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.tesourodireto.com.br"/>
                 </para>
               </entry>
             </row>
@@ -876,63 +815,78 @@
               </entry>
 
               <entry>
-                <para>tsx
+                <para>tsx or tmx
                 </para>
               </entry>
 
               <entry>
-                <para><ulink url="https://www.TMXmoney.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>T. Rowe Price, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>troweprice_direct
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.troweprice.com"/>
+                <para><ulink url="https://money.tmx.com"/>
                 </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                <para>Trustnet via tnetuk.pm, GB
+                <para>Tradegate, DE
                 </para>
               </entry>
 
               <entry>
-                <para>tnetuk
+                <para>tradegate
                 </para>
               </entry>
 
               <entry>
-                <para><ulink url="https://www.trustnet.com"/>
+                <para>Part of <ulink url="https://web.s-investor.de"/>
                 </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                <para>Trustnet via trustnet.pm, GB
+                <para>Treasury Direct bonds, US
                 </para>
               </entry>
 
               <entry>
-                <para>trustnet
+                <para>treasurydirect
                 </para>
               </entry>
 
               <entry>
-                <para><ulink url="https://www.trustnet.com"/>
+                <para><ulink url="https://www.treasurydirect.gov"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Twelve Data
+                </para>
+              </entry>
+
+              <entry>
+                <para>twelvedata
+                </para>
+              </entry>
+
+              <entry>
+                <para>You need to
+                  <orderedlist spacing="compact">
+                    <listitem>
+                      <para>register at <ulink url="https://twelvedata.com"/> and
+                        <important>
+                          <para>Watch the restrictions of the Free API Key in their pricing info!
+                          </para>
+                        </important>
+                      </para>
+                    </listitem>
+
+                    <listitem>
+                      <para>Export the key as <envar>TWELVEDATA_API_KEY</envar> environment variable before starting &appname;.
+                      </para>
+                    </listitem>
+                  </orderedlist>
                 </para>
               </entry>
             </row>
@@ -956,23 +910,6 @@
 
             <row>
               <entry>
-                <para>US Treasury Bonds, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>usfedbonds
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.publicdebt.treas.gov"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
                 <para>US Govt. Thrift Savings Plan, US
                 </para>
               </entry>
@@ -990,81 +927,17 @@
 
             <row>
               <entry>
-                <para>Vanguard, US
+                <para>XETRA, DE
                 </para>
               </entry>
 
               <entry>
-                <para>vanguard
+                <para>xetra
                 </para>
               </entry>
 
               <entry>
-                <para>part of AlphaVantage
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>VWD, DE (unmaintained)
-                </para>
-              </entry>
-
-              <entry>
-                <para>vwd
-                </para>
-              </entry>
-
-              <entry>
-                <para>See <ulink url="&url-mail-ar;gnucash-user/2008-February/023686.html"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Yahoo USA
-                </para>
-
-                <para>Yahoo Asia
-                </para>
-
-                <para>Yahoo Australia
-                </para>
-
-                <para>Yahoo Brasil
-                </para>
-
-                <para>Yahoo Europe
-                </para>
-
-                <para>Yahoo New Zealand
-                </para>
-              </entry>
-
-              <entry>
-                <para>yahoo
-                </para>
-
-                <para>yahoo_asia
-                </para>
-
-                <para>yahoo_australia
-                </para>
-
-                <para>yahoo_brasil
-                </para>
-
-                <para>yahoo_europe
-                </para>
-
-                <para>yahoo_nz
-                </para>
-              </entry>
-
-              <entry>
-                <para>CSV interface since 2017-11-01 shut off
+                <para>Part of <ulink url="https://web.s-investor.de"/>
                 </para>
               </entry>
             </row>
@@ -1081,44 +954,62 @@
               </entry>
 
               <entry>
-                <para><ulink url="&url-yh-fin;"/> through "JavaScript Object Notation"
+                <para><ulink url="&url-yh-fin;"/> through "JavaScript Object Notation" (query1/v7)
                 </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                <para>Yahoo as YQL, US
+                <para>Yahoo, US
                 </para>
               </entry>
 
               <entry>
-                <para>yahoo_yql
+                <para>yahooweb
                 </para>
               </entry>
 
               <entry>
-                <para><ulink url="&url-yh-fin;"/> through "Yahoo Query Language"
+                <para><ulink url="&url-yh-fin;"/> through "JavaScript Object Notation" (query2/v1)
                 </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                <para>Zuerich Investments (replaced)
+                <para>YH Finance (FincanceAPI)
                 </para>
               </entry>
 
               <entry>
-                <para>zifunds
+                <para>financeapi
                 </para>
               </entry>
 
               <entry>
-                <para>Zürich Invest has been purchased by Deutsche Bank and integrated into DWS.
+                <para>You need to
+                  <orderedlist spacing="compact">
+                    <listitem>
+                      <para>register at <ulink url="https://financeapi.net"/> and
+                        <important>
+                          <para>Watch the restrictions of the Free API Key in their pricing info!
+                          </para>
+                        </important>
+                      </para>
+                    </listitem>
+
+                    <listitem>
+                      <para>store the key which you got there in &mc.ed.pref; <xref linkend="prefs-online-quotes" />.
+                      </para>
+                    </listitem>
+                  </orderedlist>
+                </para>
+                <para>
                 </para>
               </entry>
             </row>
+
           </tbody>
         </tgroup>
       </table>
@@ -1142,14 +1033,7 @@
               </entry>
             </row>
           </thead>
-
           <tbody>
-            <row>
-              <entry>
-                Asia disappeared with Yahoo
-              </entry>
-            </row>
-
             <row>
               <entry>
                 Australia (ASX, ...)
@@ -1158,19 +1042,7 @@
 
             <row>
               <entry>
-                Brasil disappeared with Yahoo
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                Canada (Alphavantage, TSX, ...)
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                Canada Mutual (Fund Library, StockHouse, ...)
+                Canada (AlphaVantage, TMX, ...)
               </entry>
             </row>
 
@@ -1182,19 +1054,19 @@
 
             <row>
               <entry>
-                Europe (asegr, bsero, hex ...)
+                Europe (ASEGR, Bourso, BVB, Consorsbank, Sinvestor, Stooq, Tradegate, XETRA, ...)
               </entry>
             </row>
 
             <row>
               <entry>
-                Greece (ASE, ...)
+                France (Bourso, ...)
               </entry>
             </row>
 
             <row>
               <entry>
-                Hungary (Bamosz, BET, ...)
+                Greece (ASEGR, ...)
               </entry>
             </row>
 
@@ -1206,43 +1078,25 @@
 
             <row>
               <entry>
-                Fidelity (Fidelity, ...)
+                Nasdaq (AlphaVantage, FinanceAPI, Fool, GoogleWeb, IEXCloud, MarketWatch, StockData, YahooJSON, ...)
               </entry>
             </row>
 
             <row>
               <entry>
-                Finland (HEX, ...)
+                NYSE (AlphaVantage, FinanceAPI, Fool, GoogleWeb, IEXCloud, MarketWatch, StockData, YahooJSON, ...)
               </entry>
             </row>
 
             <row>
               <entry>
-                First Trust (First Trust, ...)
+                Poland (Stooq, ...)
               </entry>
             </row>
 
             <row>
               <entry>
-                France (Boursorama, LeRevenu, ...)
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                Nasdaq (Alphavantage, Fool, ...)
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                New Zealand (NZX, ...)
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                NYSE (Alphavantage, Fool, ...)
+                Romania (BVB, ...)
               </entry>
             </row>
 
@@ -1254,31 +1108,19 @@
 
             <row>
               <entry>
-                Romania (bsero, ...)
-              </entry>
-            </row>
-
-            <row>
-              <entry>
                 T. Rowe Price
               </entry>
             </row>
 
             <row>
               <entry>
-                U.K. Funds (citywire, FTfunds, MStar, tnetuk, ...)
+                U.K. Funds (FTfunds, MorningStarUK, ...)
               </entry>
             </row>
 
             <row>
               <entry>
-                U.K. Unit Trusts (trustnet, ...)
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                USA (Alphavantage, Fool ...)
+                USA (AlphaVantage, FinanceAPI, Fool, IEXCloud, YahooJSON, ...)
               </entry>
             </row>
           </tbody>
@@ -1286,7 +1128,7 @@
       </table>
 
       <para>Sources: src/engine/gnc-commodity.c:gnc_quote_source (commit c0fd3b3, which was adjusted for
-        Finance::Quote 1.47), <ulink url="&url-wiki;">&appname;-Wiki</ulink>,
+        Finance::Quote 1.63), <ulink url="&url-wiki;">&appname;-Wiki</ulink>,
         <ulink url="&url-bug-start;page.cgi?id=browse.html&amp;product=GnuCash">bugzilla</ulink>,
         <ulink url="&url-wiki-ml;#Mailing_List_Archives">mailing list archive</ulink>.
       </para>
@@ -6456,5 +6298,680 @@ bogus_symbol2,price2,date2
     <para>Source: Comments in
       <ulink url="https://rt.cpan.org/Ticket/Attachment/1121440/589997/Tiaacref.pm.zip"/>
     </para>
+  </sect1>
+  <sect1 id="fq-deprecated-sources">
+    <title>Deprecated Finance::Quote Sources</title>
+
+    <para>This section provides information about sources that used to be provided by <application>Finance::Quote</application>
+      but have already been removed or have been not functioning correctly.
+    </para>
+
+    <sect2 id="fq-deprecated-sources-single">
+      <title>Deprecated Quote Sources - Individual sources</title>
+
+      <table frame="topbot" id="gnc-tbl-fq-deprecated-individual-source">
+        <title>Deprecated individual sources for quotes</title>
+
+        <tgroup cols="3">
+          <thead>
+            <row>
+              <entry>
+                <para>&appname; Name
+                </para>
+              </entry>
+
+              <entry>
+                <para>Finance::Quote Name
+                </para>
+              </entry>
+
+              <entry>
+                <para>URL, Notes
+                </para>
+              </entry>
+            </row>
+          </thead>
+
+          <tbody valign='middle'>
+            <row>
+              <entry>
+                <para>American International Assurance, HK
+                </para>
+              </entry>
+
+              <entry>
+                <para>aiahk
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.aia.com.hk"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>BAMOSZ funds, HU
+                </para>
+              </entry>
+
+              <entry>
+                <para>bamosz
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.bamosz.hu"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>BMO NesbittBurns, CA
+                </para>
+              </entry>
+
+              <entry>
+                <para>bmonesbittburns
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://bmonesbittburns.com"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Budapest Stock Exchange (BET), ex-BUX, HU
+                </para>
+              </entry>
+
+              <entry>
+                <para>bse or bet
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.bet.hu"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Citywire Funds, GB
+                </para>
+              </entry>
+
+              <entry>
+                <para>citywire
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://citywire.co.uk"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Colombo Stock Exchange, LK
+                </para>
+              </entry>
+
+              <entry>
+                <para>cse
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.cse.lk"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Cominvest Asset Management, ex-Adig, DE
+                </para>
+              </entry>
+
+              <entry>
+                <para>cominvest
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.cominvest-am.de"/>
+                </para>
+
+                <para>Obsolete, update: <ulink url="https://eggert.org/software/Comdirect.pm"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Equinox Unit Trusts, ZA
+                </para>
+              </entry>
+
+              <entry>
+                <para>za_unittrusts
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.equinox.co.za"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Fidelity Investments, US
+                </para>
+              </entry>
+
+              <entry>
+                <para>fidelity_direct
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.fidelity.com"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Fidelity Fixed, US
+                </para>
+              </entry>
+
+              <entry>
+                <para>fidelityfixed
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.fidelity.com/fixed-income-bonds/overview"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Finance Canada
+                </para>
+              </entry>
+
+              <entry>
+                <para>financecanada
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://finance.canada.com"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>First Trust Portfolios, US
+                </para>
+              </entry>
+
+              <entry>
+                <para>ftportfolios_direct
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.ftportfolios.com"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Fund Library, CA
+                </para>
+              </entry>
+
+              <entry>
+                <para>fundlibrary
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.fundlibrary.com"/>
+                </para>
+
+                <para>This module uses an id that represents the mutual fund on
+                  <ulink url="https://www.fundlibrary.com"/>. There is no easy way of fetching the
+                  id except to jump onto the fundlibrary website, look up the fund and view the url
+                  for clues to its id number.
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>HElsinki stock eXchange, FI
+                </para>
+              </entry>
+
+              <entry>
+                <para>hex
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.hex.com"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Man Investments, AU
+                </para>
+              </entry>
+
+              <entry>
+                <para>maninv
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.maninvestments.com.au"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Morningstar, SE
+                </para>
+              </entry>
+
+              <entry>
+                <para>morningstar
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.morningstar.se"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Paris Stock Exchange/LeRevenu, FR
+                </para>
+              </entry>
+
+              <entry>
+                <para>lerevenu
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://bourse.lerevenu.com"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Platinum Asset Management, AU
+                </para>
+              </entry>
+
+              <entry>
+                <para>platinum
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.platinum.com.au"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>SIX Swiss Exchange Funds, CH
+                </para>
+              </entry>
+
+              <entry>
+                <para>sixfunds
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.six-swiss-exchange.com"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>SIX Swiss Exchange Shares, CH
+                </para>
+              </entry>
+
+              <entry>
+                <para>sixshares
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.six-swiss-exchange.com"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>StockHouse Canada, CA
+                </para>
+              </entry>
+
+              <entry>
+                <para>stockhousecanada_fund
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.stockhouse.ca"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TD Waterhouse Funds, CA
+                </para>
+              </entry>
+
+              <entry>
+                <para>tdwaterhouse
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.tdassetmanagement.com"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TD Efunds, CA
+                </para>
+              </entry>
+
+              <entry>
+                <para>tdefunds
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.tdwaterhouse.ca"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Trustnet via tnetuk.pm, GB
+                </para>
+              </entry>
+
+              <entry>
+                <para>tnetuk
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.trustnet.com"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Trustnet via trustnet.pm, GB
+                </para>
+              </entry>
+
+              <entry>
+                <para>trustnet
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.trustnet.com"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>US Treasury Bonds, US
+                </para>
+              </entry>
+
+              <entry>
+                <para>usfedbonds
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="https://www.publicdebt.treas.gov"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Vanguard, US
+                </para>
+              </entry>
+
+              <entry>
+                <para>vanguard
+                </para>
+              </entry>
+
+              <entry>
+                <para>part of AlphaVantage
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>VWD, DE (unmaintained)
+                </para>
+              </entry>
+
+              <entry>
+                <para>vwd
+                </para>
+              </entry>
+
+              <entry>
+                <para>See <ulink url="&url-mail-ar;gnucash-user/2008-February/023686.html"/>
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Yahoo USA
+                </para>
+
+                <para>Yahoo Asia
+                </para>
+
+                <para>Yahoo Australia
+                </para>
+
+                <para>Yahoo Brasil
+                </para>
+
+                <para>Yahoo Europe
+                </para>
+
+                <para>Yahoo New Zealand
+                </para>
+              </entry>
+
+              <entry>
+                <para>yahoo
+                </para>
+
+                <para>yahoo_asia
+                </para>
+
+                <para>yahoo_australia
+                </para>
+
+                <para>yahoo_brasil
+                </para>
+
+                <para>yahoo_europe
+                </para>
+
+                <para>yahoo_nz
+                </para>
+              </entry>
+
+              <entry>
+                <para>CSV interface since 2017-11-01 shut off
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Yahoo as YQL, US
+                </para>
+              </entry>
+
+              <entry>
+                <para>yahoo_yql
+                </para>
+              </entry>
+
+              <entry>
+                <para><ulink url="&url-yh-fin;"/> through "Yahoo Query Language"
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Zuerich Investments (replaced)
+                </para>
+              </entry>
+
+              <entry>
+                <para>zifunds
+                </para>
+              </entry>
+
+              <entry>
+                <para>Zürich Invest has been purchased by Deutsche Bank and integrated into DWS.
+                </para>
+              </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </sect2>
+
+    <sect2 id="fq-deprecated-sources-multiple">
+      <title>Deprecated Finance::Quote Sources - Multiple sources</title>
+
+      <table frame="topbot" id="gnc-tbl-fq-deprecated-multiple-source">
+        <title>Deprecated Multiple sources for quotes</title>
+
+        <tgroup cols="1">
+          <thead>
+            <row>
+              <entry>
+                <para>Name
+                </para>
+              </entry>
+            </row>
+          </thead>
+
+          <tbody>
+            <row>
+              <entry>
+                Asia disappeared with Yahoo
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                Brasil disappeared with Yahoo
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                Fidelity (Fidelity, ...)
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                Finland (HEX, ...)
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                First Trust (First Trust, ...)
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                Hungary (Bamosz, BET, ...)
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                New Zealand (NZX, ...)
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                U.K. Unit Trusts (trustnet, ...)
+              </entry>
+            </row>
+
+          </tbody>
+        </tgroup>
+      </table>
+
+    </sect2>
   </sect1>
 </appendix>

--- a/C/manual/tips-appendix.docbook
+++ b/C/manual/tips-appendix.docbook
@@ -265,7 +265,7 @@
 
               <row>
                 <entry>
-                  <para>Borsa Italiana, IT
+                  <para>Italian Stock Exchange, IT
                   </para>
                 </entry>
 
@@ -299,7 +299,7 @@
 
               <row>
                 <entry>
-                  <para>Bucharest Stock Exchange (Bursa de Valori Bucuresti), RO
+                  <para>Bucharest Stock Exchange, RO
                   </para>
                 </entry>
 

--- a/C/manual/tips-appendix.docbook
+++ b/C/manual/tips-appendix.docbook
@@ -140,7 +140,7 @@
             <tbody valign='middle'>
               <row>
                 <entry>
-                  <para>AlphaVantage, US
+                  <para>AlphaVantage
                   </para>
                 </entry>
 

--- a/C/manual/tips-appendix.docbook
+++ b/C/manual/tips-appendix.docbook
@@ -57,7 +57,7 @@
     <title>Finance::Quote Sources</title>
 
     <para>There are 3 types of sources of which the first - currency - is hardcoded and responsible to fetch
-      ISO currencies. The other two can be selected in the security editor.
+      ISO currencies. The other two can be selected in the <xref linkend="tool-security-edit"/>.
     </para>
 
     <sect2 id="fq-currencies">

--- a/C/manual/tips-appendix.docbook
+++ b/C/manual/tips-appendix.docbook
@@ -63,7 +63,7 @@
     </para>
 
     <sect2 id="fq-currencies">
-      <title>Finance::Quote Sources - Currency source</title>
+      <title>Finance::Quote Sources - Currency Source</title>
 
       <table frame="topbot" id="gnc-tbl-fq-currency-source">
         <title>Currency source for Finance::Quote</title>

--- a/C/manual/tips-appendix.docbook
+++ b/C/manual/tips-appendix.docbook
@@ -34,14 +34,29 @@
   <title>&app; Tips and tidbits</title>
 
   <abstract>
-    <para>This chapter gives you some background information about <application>Finance::Quote</application>.
+    <para>This chapter gives you some background information about <application>Finance::Quote</application>.  Due to
+      nature of gathering finance quotes (web scrapping, unstable API) the list of quote sources is constantly evolving.
+    </para>
+
+    <para>Some modules are considered Active, that means it should be possible to fetch quotes using them. Please
+    see <link linkend='fq-active-sources-single'>Active Individual Quote Sources</link>
+    and <link linkend='fq-active-sources-multiple'>Active Multiple Quote Sources</link> for detailed lists.
+    </para>
+
+    <para>Some sources may be considered obsolete that means that support for them has been removed (or is being
+    removed), or they are not functioning correctly. Please see <link linkend='fq-obsolete-sources-single'>Obsolete
+    Single Quote Sources</link> and <link linkend='fq-obsolete-sources-multiple'>Obsolete Multiple Quote Sources</link>
+    for detailed list.
+    </para>
+
+    <para>If a particular source is the only place where the quote can be obtained but it's been failing or is obsolete,
+    please reach out to <application>Finance::Quote</application> maintainers at
+    <ulink url="https://github.com/finance-quote/finance-quote"/>.
     </para>
   </abstract>
 
   <sect1 id="fq-sources">
     <title>Finance::Quote Sources</title>
-    <para>Please also consult <link linkend='fq-obsolete-sources'>Obsolete Finance::Quote Sources</link> for a list of obsolete sources.
-    </para>
 
     <para>There are 3 types of sources of which the first - currency - is hardcoded and responsible to fetch
       ISO currencies. The other two can be selected in the security editor.
@@ -97,939 +112,1522 @@
     </sect2>
 
     <sect2 id="fq-sources-single">
-      <title>Quote Sources - Individual sources</title>
-
-      <table frame="topbot" id="gnc-tbl-fq-individual-source">
-        <title>Individual sources for quotes</title>
-
-        <tgroup cols="3">
-          <thead>
-            <row>
-              <entry>
-                <para>&appname; Name
-                </para>
-              </entry>
-
-              <entry>
-                <para>Finance::Quote Name
-                </para>
-              </entry>
-
-              <entry>
-                <para>URL, Notes
-                </para>
-              </entry>
-            </row>
-          </thead>
-
-          <tbody valign='middle'>
-            <row>
-              <entry>
-                <para>AlphaVantage, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>alphavantage
-                </para>
-              </entry>
-
-              <entry>
-                <para>You need to
-                  <orderedlist spacing="compact">
-                    <listitem>
-                      <para>register at <ulink url="&url-av;"/> and
-                        <important>
-                          <para>Watch the restrictions of the Free API Key in their FAQ!
-                          </para>
-                        </important>
-                      </para>
-                    </listitem>
-
-                    <listitem>
-                      <para>store the key which you got there in &mc.ed.pref; <xref linkend="prefs-online-quotes" />.
-                      </para>
-                    </listitem>
-                  </orderedlist>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Amsterdam Euronext eXchange, NL
-                </para>
-              </entry>
-
-              <entry>
-                <para>aex
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://live.euronext.com"/>
-                </para>
-
-                <para>includes former sources AEX-<quote>Futures</quote> and -<quote>Options</quote>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Association of Mutual Funds In India, IN
-                </para>
-              </entry>
-
-              <entry>
-                <para>amfiindia
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.amfiindia.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Athens Stock Exchange, GR
-                </para>
-              </entry>
-
-              <entry>
-                <para>asegr
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.athexgroup.gr"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Australian Stock Exchange, AU
-                </para>
-              </entry>
-
-              <entry>
-                <para>asx
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.asx.com.au"/>
-                </para>
-
-                <para>Requires at least F::Q 1.41 to get quotes for stocks starting with 'X', like <quote>XRO</quote>,
-                  which are not indices.
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Bloomberg
-                </para>
-              </entry>
-
-              <entry>
-                <para>bloomberg
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.bloomberg.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Borsa Italiana, IT
-                </para>
-              </entry>
-
-              <entry>
-                <para>borsa_italiana
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.borsaitaliana.it"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>BSE India (formerly known as Bombay Stock Exchange Ltd.), IN
-                </para>
-              </entry>
-
-              <entry>
-                <para>bseindia
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.bseindia.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Bucharest Stock Exchange (Bursa de Valori Bucuresti), RO
-                </para>
-              </entry>
-
-              <entry>
-                <para>bvb or tradeville
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.bvb.ro"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Colombo Stock Exchange, LK
-                </para>
-              </entry>
-
-              <entry>
-                <para>cse
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.cse.lk"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>comdirect, DE
-                </para>
-              </entry>
-
-              <entry>
-                <para>comdirect
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.comdirect.de"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Consors Bank, DE
-                </para>
-              </entry>
-
-              <entry>
-                <para>consorsbank
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.consorsbank.de"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Deka Investments, DE
-                </para>
-              </entry>
-
-              <entry>
-                <para>deka
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.deka.de"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>DWS, DE
-                </para>
-              </entry>
-
-              <entry>
-                <para>dwsfunds
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.dws.de"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Financial Times Funds service, GB
-                </para>
-              </entry>
-
-              <entry>
-                <para>ftfunds
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://funds.ft.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Finanzpartner, DE
-                </para>
-              </entry>
-
-              <entry>
-                <para>finanzpartner
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.finanzpartner.de"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>FondsWeb, DE
-                </para>
-              </entry>
-
-              <entry>
-                <para>fondsweb
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.fondsweb.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>GoldMoney precious metals
-                </para>
-              </entry>
-
-              <entry>
-                <para>goldmoney
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.goldmoney.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Google Web, US Stocks
-                </para>
-              </entry>
-
-              <entry>
-                <para>googleweb or bats
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.google.com/finance"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>IEX (Investors Exchange), US
-                </para>
-              </entry>
-
-              <entry>
-                <para>iexcloud
-                </para>
-              </entry>
-
-              <entry>
-                <para>You need to
-                  <orderedlist spacing="compact">
-                    <listitem>
-                      <para>register at <ulink url="https://iexcloud.io"/> and
-                        <important>
-                          <para>Watch the restrictions of the Free API Key in their pricing info!
-                          </para>
-                        </important>
-                      </para>
-                    </listitem>
-
-                    <listitem>
-                      <para>Export the key as <envar>IEXCLOUD_API_KEY</envar> environment variable before starting &appname;.
-                      </para>
-                    </listitem>
-                  </orderedlist>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>MarketWatch
-                </para>
-              </entry>
-
-              <entry>
-                <para>marketwatch
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.marketwatch.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Morningstar, CH
-                </para>
-              </entry>
-
-              <entry>
-                <para>morningstarch
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.morningstar.ch"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Morningstar, GB
-                </para>
-              </entry>
-
-              <entry>
-                <para>morningstaruk or mstaruk
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://morningstar.co.uk"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Morningstar, JP
-                </para>
-              </entry>
-
-              <entry>
-                <para>morningstarjp
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.morningstar.co.jp"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Motley Fool, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>fool
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.fool.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>New Zealand stock eXchange, NZ
-                </para>
-              </entry>
-
-              <entry>
-                <para>nzx
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.nzx.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>NSE (National Stock Exchange), IN
-                </para>
-              </entry>
-
-              <entry>
-                <para>nseindia
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.nseindia.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>OnVista, DE
-                </para>
-              </entry>
-
-              <entry>
-                <para>onvista
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.onvista.de"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Paris Stock Exchange/Boursorama, FR
-                </para>
-              </entry>
-
-              <entry>
-                <para>bourso
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.boursorama.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>S-Investor, DE
-                </para>
-              </entry>
-
-              <entry>
-                <para>sinvestor
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://web.s-investor.de"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Sharenet, ZA
-                </para>
-              </entry>
-
-              <entry>
-                <para>za
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.sharenet.co.za"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>SIX Swiss Exchange, CH
-                </para>
-              </entry>
-
-              <entry>
-                <para>six
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.six-group.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Skandinaviska Enskilda Banken funds, SE
-                </para>
-              </entry>
-
-              <entry>
-                <para>seb_funds
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.seb.se"/>
-                </para>
-
-                <para>Consult <ulink url="https://taz.vv.sebank.se/cgi-bin/pts3/pow/Fonder/kurser/kurslista_body.asp"/>
-                  for all available funds.
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>StockData
-                </para>
-              </entry>
-
-              <entry>
-                <para>stockdata
-                </para>
-              </entry>
-
-              <entry>
-                <para>You need to
-                  <orderedlist spacing="compact">
-                    <listitem>
-                      <para>register at <ulink url="https://www.stockdata.org"/> and
-                        <important>
-                          <para>Watch the restrictions of the Free API Key in their pricing info!
-                          </para>
-                        </important>
-                      </para>
-                    </listitem>
-
-                    <listitem>
-                      <para>Export the key as <envar>STOCKDATA_API_KEY</envar> environment variable before starting &appname;.
-                      </para>
-                    </listitem>
-                  </orderedlist>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Stooq, PL
-                </para>
-              </entry>
-
-              <entry>
-                <para>stooq
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://stooq.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>T. Rowe Price, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>troweprice or troweprice_direct
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.troweprice.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Tesouro Direto bonds, BR
-                </para>
-              </entry>
-
-              <entry>
-                <para>torouro_direto
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.tesourodireto.com.br"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>TIAA-CREF, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>tiaacref
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.tiaa-cref.org"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Toronto Stock eXchange, CA
-                </para>
-              </entry>
-
-              <entry>
-                <para>tsx or tmx
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://money.tmx.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Tradegate, DE
-                </para>
-              </entry>
-
-              <entry>
-                <para>tradegate
-                </para>
-              </entry>
-
-              <entry>
-                <para>Part of <ulink url="https://web.s-investor.de"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Treasury Direct bonds, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>treasurydirect
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.treasurydirect.gov"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Twelve Data
-                </para>
-              </entry>
-
-              <entry>
-                <para>twelvedata
-                </para>
-              </entry>
-
-              <entry>
-                <para>You need to
-                  <orderedlist spacing="compact">
-                    <listitem>
-                      <para>register at <ulink url="https://twelvedata.com"/> and
-                        <important>
-                          <para>Watch the restrictions of the Free API Key in their pricing info!
-                          </para>
-                        </important>
-                      </para>
-                    </listitem>
-
-                    <listitem>
-                      <para>Export the key as <envar>TWELVEDATA_API_KEY</envar> environment variable before starting &appname;.
-                      </para>
-                    </listitem>
-                  </orderedlist>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Union Investment, DE
-                </para>
-              </entry>
-
-              <entry>
-                <para>unionfunds
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.union-invest.de"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>US Govt. Thrift Savings Plan, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>tsp
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.tsp.gov"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>XETRA, DE
-                </para>
-              </entry>
-
-              <entry>
-                <para>xetra
-                </para>
-              </entry>
-
-              <entry>
-                <para>Part of <ulink url="https://web.s-investor.de"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Yahoo as JSON, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>yahoo_json
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="&url-yh-fin;"/> through "JavaScript Object Notation" (query1/v7)
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Yahoo, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>yahooweb
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="&url-yh-fin;"/> through "JavaScript Object Notation" (query2/v1)
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>YH Finance (FincanceAPI)
-                </para>
-              </entry>
-
-              <entry>
-                <para>financeapi
-                </para>
-              </entry>
-
-              <entry>
-                <para>You need to
-                  <orderedlist spacing="compact">
-                    <listitem>
-                      <para>register at <ulink url="https://financeapi.net"/> and
-                        <important>
-                          <para>Watch the restrictions of the Free API Key in their pricing info!
-                          </para>
-                        </important>
-                      </para>
-                    </listitem>
-
-                    <listitem>
-                      <para>store the key which you got there in &mc.ed.pref; <xref linkend="prefs-online-quotes" />.
-                      </para>
-                    </listitem>
-                  </orderedlist>
-                </para>
-                <para>
-                </para>
-              </entry>
-            </row>
-
-          </tbody>
-        </tgroup>
-      </table>
+      <title>Finance::Quote Sources - Individual Sources</title>
+      <sect3 id="fq-active-sources-single">
+        <title>Active Individual Quote Sources</title>
+
+        <table frame="topbot" id="gnc-tbl-fq-active-individual-source">
+          <title>Individual sources for quotes</title>
+
+          <tgroup cols="3">
+            <thead>
+              <row>
+                <entry>
+                  <para>&appname; Name
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>Finance::Quote Name
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>URL, Notes
+                  </para>
+                </entry>
+              </row>
+            </thead>
+
+            <tbody valign='middle'>
+              <row>
+                <entry>
+                  <para>AlphaVantage, US
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>alphavantage
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>You need to
+                    <orderedlist spacing="compact">
+                      <listitem>
+                        <para>register at <ulink url="&url-av;"/> and
+                          <important>
+                            <para>Watch the restrictions of the Free API Key in their FAQ!
+                            </para>
+                          </important>
+                        </para>
+                      </listitem>
+
+                      <listitem>
+                        <para>store the key which you got there in &mc.ed.pref; <xref linkend="prefs-online-quotes" />.
+                        </para>
+                      </listitem>
+                    </orderedlist>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Amsterdam Euronext eXchange, NL
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>aex
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://live.euronext.com"/>
+                  </para>
+
+                  <para>includes former sources AEX-<quote>Futures</quote> and -<quote>Options</quote>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Association of Mutual Funds In India, IN
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>amfiindia
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.amfiindia.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Athens Stock Exchange, GR
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>asegr
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.athexgroup.gr"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Australian Stock Exchange, AU
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>asx
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.asx.com.au"/>
+                  </para>
+
+                  <para>Requires at least F::Q 1.41 to get quotes for stocks starting with 'X', like <quote>XRO</quote>,
+                    which are not indices.
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Bloomberg
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>bloomberg
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.bloomberg.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Borsa Italiana, IT
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>borsa_italiana
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.borsaitaliana.it"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>BSE India (formerly known as Bombay Stock Exchange Ltd.), IN
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>bseindia
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.bseindia.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Bucharest Stock Exchange (Bursa de Valori Bucuresti), RO
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>bvb or tradeville
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.bvb.ro"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Colombo Stock Exchange, LK
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>cse
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.cse.lk"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>comdirect, DE
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>comdirect
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.comdirect.de"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Consors Bank, DE
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>consorsbank
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.consorsbank.de"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Deka Investments, DE
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>deka
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.deka.de"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>DWS, DE
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>dwsfunds
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.dws.de"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Financial Times Funds service, GB
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>ftfunds
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://funds.ft.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Finanzpartner, DE
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>finanzpartner
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.finanzpartner.de"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>FondsWeb, DE
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>fondsweb
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.fondsweb.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>GoldMoney precious metals
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>goldmoney
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.goldmoney.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Google Web, US Stocks
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>googleweb or bats
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.google.com/finance"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>IEX (Investors Exchange), US
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>iexcloud
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>You need to
+                    <orderedlist spacing="compact">
+                      <listitem>
+                        <para>register at <ulink url="https://iexcloud.io"/> and
+                          <important>
+                            <para>Watch the restrictions of the Free API Key in their pricing info!
+                            </para>
+                          </important>
+                        </para>
+                      </listitem>
+
+                      <listitem>
+                        <para>Export the key as <envar>IEXCLOUD_API_KEY</envar> environment variable before starting &appname;.
+                        </para>
+                      </listitem>
+                    </orderedlist>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>MarketWatch
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>marketwatch
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.marketwatch.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Morningstar, CH
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>morningstarch
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.morningstar.ch"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Morningstar, GB
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>morningstaruk or mstaruk
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://morningstar.co.uk"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Morningstar, JP
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>morningstarjp
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.morningstar.co.jp"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Motley Fool, US
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>fool
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.fool.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>New Zealand stock eXchange, NZ
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>nzx
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.nzx.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>NSE (National Stock Exchange), IN
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>nseindia
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.nseindia.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>OnVista, DE
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>onvista
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.onvista.de"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Paris Stock Exchange/Boursorama, FR
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>bourso
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.boursorama.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>S-Investor, DE
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>sinvestor
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://web.s-investor.de"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Sharenet, ZA
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>za
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.sharenet.co.za"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>SIX Swiss Exchange, CH
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>six
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.six-group.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Skandinaviska Enskilda Banken funds, SE
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>seb_funds
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.seb.se"/>
+                  </para>
+
+                  <para>Consult <ulink url="https://taz.vv.sebank.se/cgi-bin/pts3/pow/Fonder/kurser/kurslista_body.asp"/>
+                    for all available funds.
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>StockData
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>stockdata
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>You need to
+                    <orderedlist spacing="compact">
+                      <listitem>
+                        <para>register at <ulink url="https://www.stockdata.org"/> and
+                          <important>
+                            <para>Watch the restrictions of the Free API Key in their pricing info!
+                            </para>
+                          </important>
+                        </para>
+                      </listitem>
+
+                      <listitem>
+                        <para>Export the key as <envar>STOCKDATA_API_KEY</envar> environment variable before starting &appname;.
+                        </para>
+                      </listitem>
+                    </orderedlist>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Stooq, PL
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>stooq
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://stooq.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>T. Rowe Price, US
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>troweprice or troweprice_direct
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.troweprice.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Tesouro Direto bonds, BR
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>torouro_direto
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.tesourodireto.com.br"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>TIAA-CREF, US
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>tiaacref
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.tiaa-cref.org"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Toronto Stock eXchange, CA
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>tsx or tmx
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://money.tmx.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Tradegate, DE
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>tradegate
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>Part of <ulink url="https://web.s-investor.de"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Treasury Direct bonds, US
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>treasurydirect
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.treasurydirect.gov"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Twelve Data
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>twelvedata
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>You need to
+                    <orderedlist spacing="compact">
+                      <listitem>
+                        <para>register at <ulink url="https://twelvedata.com"/> and
+                          <important>
+                            <para>Watch the restrictions of the Free API Key in their pricing info!
+                            </para>
+                          </important>
+                        </para>
+                      </listitem>
+
+                      <listitem>
+                        <para>Export the key as <envar>TWELVEDATA_API_KEY</envar> environment variable before starting &appname;.
+                        </para>
+                      </listitem>
+                    </orderedlist>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Union Investment, DE
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>unionfunds
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.union-invest.de"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>US Govt. Thrift Savings Plan, US
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>tsp
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.tsp.gov"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>XETRA, DE
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>xetra
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>Part of <ulink url="https://web.s-investor.de"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Yahoo as JSON, US
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>yahoo_json
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="&url-yh-fin;"/> through "JavaScript Object Notation" (query1/v7)
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Yahoo, US
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>yahooweb
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="&url-yh-fin;"/> through "JavaScript Object Notation" (query2/v1)
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>YH Finance (FincanceAPI)
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>financeapi
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>You need to
+                    <orderedlist spacing="compact">
+                      <listitem>
+                        <para>register at <ulink url="https://financeapi.net"/> and
+                          <important>
+                            <para>Watch the restrictions of the Free API Key in their pricing info!
+                            </para>
+                          </important>
+                        </para>
+                      </listitem>
+
+                      <listitem>
+                        <para>store the key which you got there in &mc.ed.pref; <xref linkend="prefs-online-quotes" />.
+                        </para>
+                      </listitem>
+                    </orderedlist>
+                  </para>
+                  <para>
+                  </para>
+                </entry>
+              </row>
+
+            </tbody>
+          </tgroup>
+        </table>
+      </sect3>
+
+      <sect3 id="fq-obsolete-sources-single">
+        <title>Obsolete Individual Quote Sources</title>
+
+        <table frame="topbot" id="gnc-tbl-fq-obsolete-individual-source">
+          <title>Obsolete individual sources for quotes</title>
+
+          <tgroup cols="3">
+            <thead>
+              <row>
+                <entry>
+                  <para>&appname; Name
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>Finance::Quote Name
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>URL, Notes
+                  </para>
+                </entry>
+              </row>
+            </thead>
+
+            <tbody valign='middle'>
+              <row>
+                <entry>
+                  <para>American International Assurance, HK
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>aiahk
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.aia.com.hk"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>BAMOSZ funds, HU
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>bamosz
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.bamosz.hu"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>BMO NesbittBurns, CA
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>bmonesbittburns
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://bmonesbittburns.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Budapest Stock Exchange (BET), ex-BUX, HU
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>bse or bet
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.bet.hu"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Citywire Funds, GB
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>citywire
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://citywire.co.uk"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Cominvest Asset Management, ex-Adig, DE
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>cominvest
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.cominvest-am.de"/>
+                  </para>
+
+                  <para>Obsolete, update: <ulink url="https://eggert.org/software/Comdirect.pm"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Equinox Unit Trusts, ZA
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>za_unittrusts
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.equinox.co.za"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Fidelity Investments, US
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>fidelity_direct
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.fidelity.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Fidelity Fixed, US
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>fidelityfixed
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.fidelity.com/fixed-income-bonds/overview"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Finance Canada
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>financecanada
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://finance.canada.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>First Trust Portfolios, US
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>ftportfolios_direct
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.ftportfolios.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Fund Library, CA
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>fundlibrary
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.fundlibrary.com"/>
+                  </para>
+
+                  <para>This module uses an id that represents the mutual fund on
+                    <ulink url="https://www.fundlibrary.com"/>. There is no easy way of fetching the
+                    id except to jump onto the fundlibrary website, look up the fund and view the url
+                    for clues to its id number.
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>HElsinki stock eXchange, FI
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>hex
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.hex.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Man Investments, AU
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>maninv
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.maninvestments.com.au"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Morningstar, SE
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>morningstar
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.morningstar.se"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Paris Stock Exchange/LeRevenu, FR
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>lerevenu
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://bourse.lerevenu.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Platinum Asset Management, AU
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>platinum
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.platinum.com.au"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>SIX Swiss Exchange Funds, CH
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>sixfunds
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.six-swiss-exchange.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>SIX Swiss Exchange Shares, CH
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>sixshares
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.six-swiss-exchange.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>StockHouse Canada, CA
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>stockhousecanada_fund
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.stockhouse.ca"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>TD Waterhouse Funds, CA
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>tdwaterhouse
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.tdassetmanagement.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>TD Efunds, CA
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>tdefunds
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.tdwaterhouse.ca"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Trustnet via tnetuk.pm, GB
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>tnetuk
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.trustnet.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Trustnet via trustnet.pm, GB
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>trustnet
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.trustnet.com"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>US Treasury Bonds, US
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>usfedbonds
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="https://www.publicdebt.treas.gov"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Vanguard, US
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>vanguard
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>part of AlphaVantage
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>VWD, DE (unmaintained)
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>vwd
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>See <ulink url="&url-mail-ar;gnucash-user/2008-February/023686.html"/>
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Yahoo USA
+                  </para>
+
+                  <para>Yahoo Asia
+                  </para>
+
+                  <para>Yahoo Australia
+                  </para>
+
+                  <para>Yahoo Brasil
+                  </para>
+
+                  <para>Yahoo Europe
+                  </para>
+
+                  <para>Yahoo New Zealand
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>yahoo
+                  </para>
+
+                  <para>yahoo_asia
+                  </para>
+
+                  <para>yahoo_australia
+                  </para>
+
+                  <para>yahoo_brasil
+                  </para>
+
+                  <para>yahoo_europe
+                  </para>
+
+                  <para>yahoo_nz
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>CSV interface since 2017-11-01 shut off
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Yahoo as YQL, US
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>yahoo_yql
+                  </para>
+                </entry>
+
+                <entry>
+                  <para><ulink url="&url-yh-fin;"/> through "Yahoo Query Language"
+                  </para>
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  <para>Zuerich Investments (replaced)
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>zifunds
+                  </para>
+                </entry>
+
+                <entry>
+                  <para>Zürich Invest has been purchased by Deutsche Bank and integrated into DWS.
+                  </para>
+                </entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </sect3>
     </sect2>
 
     <sect2 id="fq-sources-multiple">
@@ -1038,5882 +1636,237 @@
       <para>Here the first successful result of a list of sources gets returned.
       </para>
 
-      <table frame="topbot" id="gnc-tbl-fq-multiple-source">
-        <title>Multiple sources for quotes</title>
+      <sect3 id="fq-active-sources-multiple">
+        <title>Active Multiple Quote Sources</title>
 
-        <tgroup cols="1">
-          <thead>
-            <row>
-              <entry>
-                <para>Name
-                </para>
-              </entry>
-            </row>
-          </thead>
-          <tbody>
-            <row>
-              <entry>
-                Australia (ASX, ...)
-              </entry>
-            </row>
+        <table frame="topbot" id="gnc-tbl-fq-active-multiple-source">
+          <title>Multiple sources for quotes</title>
 
-            <row>
-              <entry>
-                Canada (AlphaVantage, TMX, ...)
-              </entry>
-            </row>
+          <tgroup cols="1">
+            <thead>
+              <row>
+                <entry>
+                  <para>Name
+                  </para>
+                </entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>
+                  Australia (ASX, ...)
+                </entry>
+              </row>
 
-            <row>
-              <entry>
-                Dutch (AEX, ...)
-              </entry>
-            </row>
+              <row>
+                <entry>
+                  Canada (AlphaVantage, TMX, ...)
+                </entry>
+              </row>
 
-            <row>
-              <entry>
-                Europe (ASEGR, Bourso, BVB, Consorsbank, Sinvestor, Stooq, Tradegate, XETRA, ...)
-              </entry>
-            </row>
+              <row>
+                <entry>
+                  Dutch (AEX, ...)
+                </entry>
+              </row>
 
-            <row>
-              <entry>
-                France (Bourso, ...)
-              </entry>
-            </row>
+              <row>
+                <entry>
+                  Europe (ASEGR, Bourso, BVB, Consorsbank, Sinvestor, Stooq, Tradegate, XETRA, ...)
+                </entry>
+              </row>
 
-            <row>
-              <entry>
-                Greece (ASEGR, ...)
-              </entry>
-            </row>
+              <row>
+                <entry>
+                  France (Bourso, ...)
+                </entry>
+              </row>
 
-            <row>
-              <entry>
-                India Mutual (AMFI, ...)
-              </entry>
-            </row>
+              <row>
+                <entry>
+                  Greece (ASEGR, ...)
+                </entry>
+              </row>
 
-            <row>
-              <entry>
-                Nasdaq (AlphaVantage, FinanceAPI, Fool, GoogleWeb, IEXCloud, MarketWatch, StockData, YahooJSON, ...)
-              </entry>
-            </row>
+              <row>
+                <entry>
+                  India Mutual (AMFI, ...)
+                </entry>
+              </row>
 
-            <row>
-              <entry>
-                NYSE (AlphaVantage, FinanceAPI, Fool, GoogleWeb, IEXCloud, MarketWatch, StockData, YahooJSON, ...)
-              </entry>
-            </row>
+              <row>
+                <entry>
+                  Nasdaq (AlphaVantage, FinanceAPI, Fool, GoogleWeb, IEXCloud, MarketWatch, StockData, YahooJSON, ...)
+                </entry>
+              </row>
 
-            <row>
-              <entry>
-                Poland (Stooq, ...)
-              </entry>
-            </row>
+              <row>
+                <entry>
+                  NYSE (AlphaVantage, FinanceAPI, Fool, GoogleWeb, IEXCloud, MarketWatch, StockData, YahooJSON, ...)
+                </entry>
+              </row>
 
-            <row>
-              <entry>
-                Romania (BVB, ...)
-              </entry>
-            </row>
+              <row>
+                <entry>
+                  Poland (Stooq, ...)
+                </entry>
+              </row>
 
-            <row>
-              <entry>
-                South Africa (Sharenet, ...)
-              </entry>
-            </row>
+              <row>
+                <entry>
+                  Romania (BVB, ...)
+                </entry>
+              </row>
 
-            <row>
-              <entry>
-                T. Rowe Price
-              </entry>
-            </row>
+              <row>
+                <entry>
+                  South Africa (Sharenet, ...)
+                </entry>
+              </row>
 
-            <row>
-              <entry>
-                U.K. Funds (FTfunds, MorningStarUK, ...)
-              </entry>
-            </row>
+              <row>
+                <entry>
+                  T. Rowe Price
+                </entry>
+              </row>
 
-            <row>
-              <entry>
-                USA (AlphaVantage, FinanceAPI, Fool, IEXCloud, YahooJSON, ...)
-              </entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
+              <row>
+                <entry>
+                  U.K. Funds (FTfunds, MorningStarUK, ...)
+                </entry>
+              </row>
 
-      <para>Sources: src/engine/gnc-commodity.c:gnc_quote_source (commit c0fd3b3, which was adjusted for
+              <row>
+                <entry>
+                  USA (AlphaVantage, FinanceAPI, Fool, IEXCloud, YahooJSON, ...)
+                </entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </sect3>
+
+      <sect3 id="fq-obsolete-sources-multiple">
+        <title>Obsolete Multiple Quote Sources</title>
+
+        <table frame="topbot" id="gnc-tbl-fq-obsolete-multiple-source">
+          <title>Obsolete Multiple sources for quotes</title>
+
+          <tgroup cols="1">
+            <thead>
+              <row>
+                <entry>
+                  <para>Name
+                  </para>
+                </entry>
+              </row>
+            </thead>
+
+            <tbody>
+              <row>
+                <entry>
+                  Asia disappeared with Yahoo
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  Brasil disappeared with Yahoo
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  Fidelity (Fidelity, ...)
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  Finland (HEX, ...)
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  First Trust (First Trust, ...)
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  Hungary (Bamosz, BET, ...)
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  New Zealand (NZX, ...)
+                </entry>
+              </row>
+
+              <row>
+                <entry>
+                  U.K. Unit Trusts (trustnet, ...)
+                </entry>
+              </row>
+
+            </tbody>
+          </tgroup>
+        </table>
+        <para>Sources: src/engine/gnc-commodity.c:gnc_quote_source (commit c0fd3b3, which was adjusted for
         Finance::Quote 1.63), <ulink url="&url-wiki;">&appname;-Wiki</ulink>,
         <ulink url="&url-bug-start;page.cgi?id=browse.html&amp;product=GnuCash">bugzilla</ulink>,
         <ulink url="&url-wiki-ml;#Mailing_List_Archives">mailing list archive</ulink>.
       </para>
+      </sect3>
     </sect2>
   </sect1>
 
-  <sect1 id="fq-spec-yahoo">
-    <title>Yahoo Specifics</title>
-
-    <abstract>
-      <para>Yahoo has offered quotes from many exchanges and markets. Alphavatage will behave similar but
-        without delay. If you are not asking for US markets, you have to specify where to look. A
-        typical Yahoo symbol has the form {&lt;ISIN&gt;|&lt;ticker&gt;}&lt;market suffix&gt;.
-      </para>
-    </abstract>
-
-    <note>
-      <title>Dots in Ticker Symbols</title>
-
-      <para>Because Yahoo uses the dot <keycap>.</keycap> as separator for the market, dots in symbols like in
-        <quote>BT.A</quote> at the <ulink url="https://www.londonstockexchange.com">London Stock
-        Exchange</ulink> are replaced by dash <keycap>-</keycap> resulting in <quote>BT-A.L</quote>.
-      </para>
-    </note>
-
-    <table frame="topbot" id="gnc-tbl-fq-yahoo-exchange-codes">
-      <title>Yahoo Codes for Exchanges and Markets</title>
-
-      <tgroup cols="4">
-        <thead>
-          <row>
-            <entry>
-              <para>Country
-              </para>
-            </entry>
-
-            <entry>
-              <para>Market or Index
-              </para>
-            </entry>
-
-            <entry>
-              <para>Suffix
-              </para>
-            </entry>
-
-            <entry>
-              <para>Delay
-              </para>
-            </entry>
-          </row>
-        </thead>
-
-        <tbody>
-          <row>
-            <entry>
-              <para>Argentina
-              </para>
-            </entry>
-
-            <entry>
-              <para>Buenos Aires Stock Exchange (BYMA)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.BA
-              </para>
-            </entry>
-
-            <entry>
-              <para>30 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Australia
-              </para>
-            </entry>
-
-            <entry>
-              <para>Australian Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.AX
-              </para>
-            </entry>
-
-            <entry>
-              <para>20 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Austria
-              </para>
-            </entry>
-
-            <entry>
-              <para>Vienna Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.VI
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Belgium
-              </para>
-            </entry>
-
-            <entry>
-              <para>Euronext Brussels
-              </para>
-            </entry>
-
-            <entry>
-              <para>.BR
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Brazil
-              </para>
-            </entry>
-
-            <entry>
-              <para>Sao Paolo Stock Exchange (BOVESPA)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.SA
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Canada
-              </para>
-            </entry>
-
-            <entry>
-              <para>Canadian Securities ExchangeToronto Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.CN
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Canada
-              </para>
-            </entry>
-
-            <entry>
-              <para>NEO Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.NE
-              </para>
-            </entry>
-
-            <entry>
-              <para>Real-time
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Canada
-              </para>
-            </entry>
-
-            <entry>
-              <para>Toronto Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.TO
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Canada
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSX Venture Exchange (TSXV)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.V
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Chile
-              </para>
-            </entry>
-
-            <entry>
-              <para>Santiago Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.SN
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>China
-              </para>
-            </entry>
-
-            <entry>
-              <para>Shanghai Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.SS
-              </para>
-            </entry>
-
-            <entry>
-              <para>30 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>China
-              </para>
-            </entry>
-
-            <entry>
-              <para>Shenzhen Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.SZ
-              </para>
-            </entry>
-
-            <entry>
-              <para>30 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Czech Republic
-              </para>
-            </entry>
-
-            <entry>
-              <para>Prague Stock Exchange Index
-              </para>
-            </entry>
-
-            <entry>
-              <para>.PR
-              </para>
-            </entry>
-
-            <entry>
-              <para>20 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Denmark
-              </para>
-            </entry>
-
-            <entry>
-              <para>Nasdaq OMX Copenhagen
-              </para>
-            </entry>
-
-            <entry>
-              <para>.CO
-              </para>
-            </entry>
-
-            <entry>
-              <para>Real-time
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Egypt
-              </para>
-            </entry>
-
-            <entry>
-              <para>Egyptian Exchange Index (EGID)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.CA
-              </para>
-            </entry>
-
-            <entry>
-              <para>20 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Estonia
-              </para>
-            </entry>
-
-            <entry>
-              <para>Nasdaq OMX Tallinn
-              </para>
-            </entry>
-
-            <entry>
-              <para>.TL
-              </para>
-            </entry>
-
-            <entry>
-              <para>Real-time
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Finland
-              </para>
-            </entry>
-
-            <entry>
-              <para>Nasdaq OMX Helsinki
-              </para>
-            </entry>
-
-            <entry>
-              <para>.HE
-              </para>
-            </entry>
-
-            <entry>
-              <para>Real-time
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>France
-              </para>
-            </entry>
-
-            <entry>
-              <para>Euronext
-              </para>
-            </entry>
-
-            <entry>
-              <para>.NX
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>France
-              </para>
-            </entry>
-
-            <entry>
-              <para>Euronext Paris
-              </para>
-            </entry>
-
-            <entry>
-              <para>.PA
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Germany
-              </para>
-            </entry>
-
-            <entry>
-              <para>Berlin Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.BE
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Germany
-              </para>
-            </entry>
-
-            <entry>
-              <para>Bremen Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.BM
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Germany
-              </para>
-            </entry>
-
-            <entry>
-              <para>Dusseldorf Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.DU
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Germany
-              </para>
-            </entry>
-
-            <entry>
-              <para>Frankfurt Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.F
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Germany
-              </para>
-            </entry>
-
-            <entry>
-              <para>Hamburg Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.HM
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Germany
-              </para>
-            </entry>
-
-            <entry>
-              <para>Hanover Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.HA
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Germany
-              </para>
-            </entry>
-
-            <entry>
-              <para>Munich Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.MU
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Germany
-              </para>
-            </entry>
-
-            <entry>
-              <para>Stuttgart Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.SG
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Germany
-              </para>
-            </entry>
-
-            <entry>
-              <para>Deutsche Boerse XETRA
-              </para>
-            </entry>
-
-            <entry>
-              <para>.DE
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Global
-              </para>
-            </entry>
-
-            <entry>
-              <para>Currency Rates
-              </para>
-            </entry>
-
-            <entry>
-              <para>=X
-              </para>
-            </entry>
-
-            <entry>
-              <para>Real-time
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Greece
-              </para>
-            </entry>
-
-            <entry>
-              <para>Athens Stock Exchange (ATHEX)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.AT
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Hong Kong
-              </para>
-            </entry>
-
-            <entry>
-              <para>Hong Kong Stock Exchange (HKEX)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.HK
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min (Real-time in HK)
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Hungary
-              </para>
-            </entry>
-
-            <entry>
-              <para>Budapest Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.BD
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Iceland
-              </para>
-            </entry>
-
-            <entry>
-              <para>Nasdaq OMX Iceland
-              </para>
-            </entry>
-
-            <entry>
-              <para>.IC
-              </para>
-            </entry>
-
-            <entry>
-              <para>Real-time
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>India
-              </para>
-            </entry>
-
-            <entry>
-              <para>Bombay Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.BO
-              </para>
-            </entry>
-
-            <entry>
-              <para>Real-time
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>India
-              </para>
-            </entry>
-
-            <entry>
-              <para>National Stock Exchange of India
-              </para>
-            </entry>
-
-            <entry>
-              <para>.NS
-              </para>
-            </entry>
-
-            <entry>
-              <para>Real-time**
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Indonesia
-              </para>
-            </entry>
-
-            <entry>
-              <para>Indonesia Stock Exchange (IDX)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.JK
-              </para>
-            </entry>
-
-            <entry>
-              <para>10 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Ireland
-              </para>
-            </entry>
-
-            <entry>
-              <para>Euronext Dublin
-              </para>
-            </entry>
-
-            <entry>
-              <para>.IR
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Israel
-              </para>
-            </entry>
-
-            <entry>
-              <para>Tel Aviv Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.TA
-              </para>
-            </entry>
-
-            <entry>
-              <para>20 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Italy
-              </para>
-            </entry>
-
-            <entry>
-              <para>EuroTLX
-              </para>
-            </entry>
-
-            <entry>
-              <para>.TI
-              </para>
-            </entry>
-
-            <entry>
-              <para>20 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Italy
-              </para>
-            </entry>
-
-            <entry>
-              <para>Italian Stock Exchange, former Milano
-              </para>
-            </entry>
-
-            <entry>
-              <para>.MI
-              </para>
-            </entry>
-
-            <entry>
-              <para>20 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Japan
-              </para>
-            </entry>
-
-            <entry>
-              <para>Nikkei Indices
-              </para>
-            </entry>
-
-            <entry>
-              <para>N/A
-              </para>
-            </entry>
-
-            <entry>
-              <para>30 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Japan
-              </para>
-            </entry>
-
-            <entry>
-              <para>Tokyo Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.T
-              </para>
-            </entry>
-
-            <entry>
-              <para>20 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Latvia
-              </para>
-            </entry>
-
-            <entry>
-              <para>Nasdaq OMX Riga
-              </para>
-            </entry>
-
-            <entry>
-              <para>.RG
-              </para>
-            </entry>
-
-            <entry>
-              <para>Real-time
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Lithuania
-              </para>
-            </entry>
-
-            <entry>
-              <para>Nasdaq OMX Vilnius
-              </para>
-            </entry>
-
-            <entry>
-              <para>.VS
-              </para>
-            </entry>
-
-            <entry>
-              <para>Real-time
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Malaysia
-              </para>
-            </entry>
-
-            <entry>
-              <para>Malaysian Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.KL
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Mexico
-              </para>
-            </entry>
-
-            <entry>
-              <para>Mexico Stock Exchange (BMV)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.MX
-              </para>
-            </entry>
-
-            <entry>
-              <para>20 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Netherlands
-              </para>
-            </entry>
-
-            <entry>
-              <para>Euronext Amsterdam
-              </para>
-            </entry>
-
-            <entry>
-              <para>.AS
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>New Zealand
-              </para>
-            </entry>
-
-            <entry>
-              <para>New Zealand Stock Exchange (NZX)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.NZ
-              </para>
-            </entry>
-
-            <entry>
-              <para>20 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Norway
-              </para>
-            </entry>
-
-            <entry>
-              <para>Oslo Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.OL
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Portugal
-              </para>
-            </entry>
-
-            <entry>
-              <para>Euronext Lisbon
-              </para>
-            </entry>
-
-            <entry>
-              <para>.LS
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Qatar
-              </para>
-            </entry>
-
-            <entry>
-              <para>Qatar Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.QA
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Russia
-              </para>
-            </entry>
-
-            <entry>
-              <para>Moscow Exchange (MOEX)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.ME
-              </para>
-            </entry>
-
-            <entry>
-              <para>Real-time
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Singapore
-              </para>
-            </entry>
-
-            <entry>
-              <para>Singapore Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.SI
-              </para>
-            </entry>
-
-            <entry>
-              <para>20 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>South Africa
-              </para>
-            </entry>
-
-            <entry>
-              <para>Johannesburg Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.Jo
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>South Korea
-              </para>
-            </entry>
-
-            <entry>
-              <para>Korea Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.KS
-              </para>
-            </entry>
-
-            <entry>
-              <para>20 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>South Korea
-              </para>
-            </entry>
-
-            <entry>
-              <para>KOSDAQ
-              </para>
-            </entry>
-
-            <entry>
-              <para>.KQ
-              </para>
-            </entry>
-
-            <entry>
-              <para>20 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Spain
-              </para>
-            </entry>
-
-            <entry>
-              <para>Madrid SE C.A.T.S.
-              </para>
-            </entry>
-
-            <entry>
-              <para>.MC
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Saudi Arabia
-              </para>
-            </entry>
-
-            <entry>
-              <para>Saudi Stock Exchange (Tadawul)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.SAU
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Sweden
-              </para>
-            </entry>
-
-            <entry>
-              <para>Nasdaq OMX Stockholm
-              </para>
-            </entry>
-
-            <entry>
-              <para>.ST
-              </para>
-            </entry>
-
-            <entry>
-              <para>Real-time
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Switzerland
-              </para>
-            </entry>
-
-            <entry>
-              <para>Swiss Exchange (SIX)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.SW
-              </para>
-            </entry>
-
-            <entry>
-              <para>30 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Taiwan
-              </para>
-            </entry>
-
-            <entry>
-              <para>Taiwan OTC Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.TWO
-              </para>
-            </entry>
-
-            <entry>
-              <para>20 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Taiwan
-              </para>
-            </entry>
-
-            <entry>
-              <para>Taiwan Stock Exchange (TWSE)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.TW
-              </para>
-            </entry>
-
-            <entry>
-              <para>20 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Thailand
-              </para>
-            </entry>
-
-            <entry>
-              <para>Stock Exchange of Thailand (SET)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.BK
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Turkey
-              </para>
-            </entry>
-
-            <entry>
-              <para>Borsa İstanbul
-              </para>
-            </entry>
-
-            <entry>
-              <para>.IS
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>United Kingdom
-              </para>
-            </entry>
-
-            <entry>
-              <para>FTSE Indices
-              </para>
-            </entry>
-
-            <entry>
-              <para>N/A
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>United Kingdom
-              </para>
-            </entry>
-
-            <entry>
-              <para>London Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.L
-              </para>
-            </entry>
-
-            <entry>
-              <para>20 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>United Kingdom
-              </para>
-            </entry>
-
-            <entry>
-              <para>London Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.IL
-              </para>
-            </entry>
-
-            <entry>
-              <para>20 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>United States of America
-              </para>
-            </entry>
-
-            <entry>
-              <para>Chicago Board of Trade (CBOT)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.CBT
-              </para>
-            </entry>
-
-            <entry>
-              <para>10 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>United States of America
-              </para>
-            </entry>
-
-            <entry>
-              <para>Chicago Mercantile Exchange (CME)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.CME
-              </para>
-            </entry>
-
-            <entry>
-              <para>10 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>United States of America
-              </para>
-            </entry>
-
-            <entry>
-              <para>Dow Jones Indexes
-              </para>
-            </entry>
-
-            <entry>
-              <para>N/A
-              </para>
-            </entry>
-
-            <entry>
-              <para>Real-time
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>United States of America
-              </para>
-            </entry>
-
-            <entry>
-              <para>NASDAQ Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>N/A
-              </para>
-            </entry>
-
-            <entry>
-              <para>Real-time*
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>United States of America
-              </para>
-            </entry>
-
-            <entry>
-              <para>ICE Futures US, former New York Board of Trade
-              </para>
-            </entry>
-
-            <entry>
-              <para>.NYB
-              </para>
-            </entry>
-
-            <entry>
-              <para>30 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>United States of America
-              </para>
-            </entry>
-
-            <entry>
-              <para>New York Commodities Exchange (COMEX)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.CMX
-              </para>
-            </entry>
-
-            <entry>
-              <para>30 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>United States of America
-              </para>
-            </entry>
-
-            <entry>
-              <para>New York Mercantile Exchange (NYMEX)
-              </para>
-            </entry>
-
-            <entry>
-              <para>.NYM
-              </para>
-            </entry>
-
-            <entry>
-              <para>30 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>United States of America
-              </para>
-            </entry>
-
-            <entry>
-              <para>Options Price Reporting Authority (OPRA)
-              </para>
-            </entry>
-
-            <entry>
-              <para>N/A
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>United States of America
-              </para>
-            </entry>
-
-            <entry>
-              <para>OTC Bulletin Board Market
-              </para>
-            </entry>
-
-            <entry>
-              <para>N/A
-              </para>
-            </entry>
-
-            <entry>
-              <para>Real-time
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>United States of America
-              </para>
-            </entry>
-
-            <entry>
-              <para>OTC Markets Group
-              </para>
-            </entry>
-
-            <entry>
-              <para>N/A
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>United States of America
-              </para>
-            </entry>
-
-            <entry>
-              <para>S &amp; P Indices
-              </para>
-            </entry>
-
-            <entry>
-              <para>N/A
-              </para>
-            </entry>
-
-            <entry>
-              <para>Real-time
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>Venezuela
-              </para>
-            </entry>
-
-            <entry>
-              <para>Caracas Stock Exchange
-              </para>
-            </entry>
-
-            <entry>
-              <para>.CR
-              </para>
-            </entry>
-
-            <entry>
-              <para>15 min
-              </para>
-            </entry>
-          </row>
-        </tbody>
-      </tgroup>
-    </table>
-
-    <para>Source: <ulink url="&url-yh-hlp;kb/SLN2310.html?redirect=true"/> queried at 2020-04-14.
-    </para>
-  </sect1>
-
-  <sect1 id="fq-spec-tiaa">
-    <title>TIAA-CREF Specifics</title>
-
-    <abstract>
-      <para>TIAA-CREF Annuities are not listed on any exchange, unlike their mutual funds TIAA-CREF provides
-        unit values via a cgi on their website. The cgi returns a csv file in the format
-<programlisting language="csv">bogus_symbol1,price1,date1
-bogus_symbol2,price2,date2
-…</programlisting>
-        where <replaceable>bogus_symbol</replaceable> takes on the following values for the various
-        annuities:
-      </para>
-    </abstract>
-
-    <note>
-      <para>The symbols are case-sensitive and changed their capitalization in the last time.
-      </para>
-    </note>
-
-    <table frame="topbot" id="PsSymbs-TIAA-CREF">
-      <title>Pseudo-symbols that can be used for TIAA-CREF quotes</title>
-
-      <tgroup cols="3">
-        <colspec colnum="1"/>
-<!-- yelp seems to ignore colnum -->
-        <colspec colnum="2"/>
-
-        <colspec colnum="3" align="right"/>
-
-        <thead>
-          <row>
-            <entry align="center">
-              <para>Name
-              </para>
-            </entry>
-
-            <entry align="center">
-              <para>Symbol
-              </para>
-            </entry>
-
-            <entry align="center">
-              <para>bogus
-              </para>
-            </entry>
-          </row>
-        </thead>
-
-        <tbody>
-          <row>
-            <entry>
-              <para>CREF Bond Market Account
-              </para>
-            </entry>
-
-            <entry>
-              <para>CREFbond
-              </para>
-            </entry>
-
-            <entry>
-              <para>41081991
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>CREF Equity Index Account
-              </para>
-            </entry>
-
-            <entry>
-              <para>CREFequi
-              </para>
-            </entry>
-
-            <entry>
-              <para>41082540
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>CREF Global Equities Account
-              </para>
-            </entry>
-
-            <entry>
-              <para>CREFglob
-              </para>
-            </entry>
-
-            <entry>
-              <para>41081992
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>CREF Growth Account
-              </para>
-            </entry>
-
-            <entry>
-              <para>CREFgrow
-              </para>
-            </entry>
-
-            <entry>
-              <para>41082544
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>CREF Inflation-Linked Bond Account
-              </para>
-            </entry>
-
-            <entry>
-              <para>CREFinfb
-              </para>
-            </entry>
-
-            <entry>
-              <para>41088773
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>CREF Money Market Account
-              </para>
-            </entry>
-
-            <entry>
-              <para>CREFmony
-              </para>
-            </entry>
-
-            <entry>
-              <para>41081993
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>CREF Social Choice Account
-              </para>
-            </entry>
-
-            <entry>
-              <para>CREFsoci
-              </para>
-            </entry>
-
-            <entry>
-              <para>41081994
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>CREF Stock Account
-              </para>
-            </entry>
-
-            <entry>
-              <para>CREFstok
-              </para>
-            </entry>
-
-            <entry>
-              <para>41081995
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA Real Estate Account
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIAAreal
-              </para>
-            </entry>
-
-            <entry>
-              <para>41091375
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Bond Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIDRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530828
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Bond Index Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TBIRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>20739662
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Bond Plus Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCBRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530816
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Emerging Markets Equity Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TEMSX
-              </para>
-            </entry>
-
-            <entry>
-              <para>26176543
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Emerging Markets Equity Index Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TEQSX
-              </para>
-            </entry>
-
-            <entry>
-              <para>26176547
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Equity Index Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIQRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530786
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Global Natural Resources Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TNRRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>39444919
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Growth &amp; Income Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRGIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>312536
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF High Yield Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIHRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530821
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Inflation-Linked Bond Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIKRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530829
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF International Equity Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRERX
-              </para>
-            </entry>
-
-            <entry>
-              <para>302323
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF International Equity Index Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRIEX
-              </para>
-            </entry>
-
-            <entry>
-              <para>300269
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Large-Cap Growth Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TILRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530785
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Large-Cap Growth Index Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRIRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>299525
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Large-Cap Value Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRLCX
-              </para>
-            </entry>
-
-            <entry>
-              <para>301332
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Large-Cap Value Index Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRCVX
-              </para>
-            </entry>
-
-            <entry>
-              <para>304333
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2010 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCLEX
-              </para>
-            </entry>
-
-            <entry>
-              <para>302817
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2015 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCLIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>302393
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2020 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCLTX
-              </para>
-            </entry>
-
-            <entry>
-              <para>307774
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2025 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCLFX
-              </para>
-            </entry>
-
-            <entry>
-              <para>313994
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2030 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCLNX
-              </para>
-            </entry>
-
-            <entry>
-              <para>307240
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2035 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCLRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>309003
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2040 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCLOX
-              </para>
-            </entry>
-
-            <entry>
-              <para>300959
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2045 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TTFRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>9467597
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2050 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLFRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>9467596
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2055 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TTRLX
-              </para>
-            </entry>
-
-            <entry>
-              <para>34211330
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2010 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLTRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066482
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2015 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLGRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066496
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2020 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLWRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066479
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2025 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLQRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066485
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2030 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLHRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066435
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2035 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLYRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066475
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2040 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLZRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066473
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2045 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLMRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066488
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2050 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLLRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066490
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2055 Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TTIRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>34211328
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index Retirement Income Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRCIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066468
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Retirement Income Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLIRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>9467594
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Aggressive Growth Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSARX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508431
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Conservative Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSCTX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508433
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Growth Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSGRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508437
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Income Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLSRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508427
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Moderate Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSMTX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508460
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Managed Allocation Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TITRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530825
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Mid-Cap Growth Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRGMX
-              </para>
-            </entry>
-
-            <entry>
-              <para>305499
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Mid-Cap Value Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRVRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>315272
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Money Market Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIEXX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530771
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Real Estate Securities Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRRSX
-              </para>
-            </entry>
-
-            <entry>
-              <para>300081
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF S&amp;P 500 Index Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRSPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>306105
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Short-Term Bond Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TISRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530818
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Small-Cap Blend Index Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRBIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>314644
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Small-Cap Equity Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRSEX
-              </para>
-            </entry>
-
-            <entry>
-              <para>299968
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Social Choice Equity Fund (Retirement)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRSCX
-              </para>
-            </entry>
-
-            <entry>
-              <para>300078
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Bond Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIBDX
-              </para>
-            </entry>
-
-            <entry>
-              <para>307276
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Bond Index Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TBIIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>20739664
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Bond Plus Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIBFX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530820
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Emerging Markets Equity Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TEMLX
-              </para>
-            </entry>
-
-            <entry>
-              <para>26176540
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Emerging Markets Equity Index Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TEQLX
-              </para>
-            </entry>
-
-            <entry>
-              <para>26176544
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Enhanced International Equity Index Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TFIIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>9467603
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Enhanced Large-Cap Growth Index Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLIIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>9467602
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Enhanced Large-Cap Value Index Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TEVIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>9467606
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Equity Index Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIEIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>301718
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Global Natural Resources Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TNRIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>39444916
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Growth &amp; Income Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIGRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>314719
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF High Yield Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIHYX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530798
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Inflation-Linked Bond Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIILX
-              </para>
-            </entry>
-
-            <entry>
-              <para>316693
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF International Equity Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIIEX
-              </para>
-            </entry>
-
-            <entry>
-              <para>305980
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF International Equity Index Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCIEX
-              </para>
-            </entry>
-
-            <entry>
-              <para>303673
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Large-Cap Growth Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TILGX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530800
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Large-Cap Growth Index Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TILIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>297809
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Large-Cap Value Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRLIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>300692
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Large-Cap Value Index Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TILVX
-              </para>
-            </entry>
-
-            <entry>
-              <para>302308
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2010 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCTIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4912376
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2015 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCNIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4912355
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2020 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCWIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4912377
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2025 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCYIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4912384
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2030 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCRIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4912364
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2035 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCIIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4912375
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2040 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCOIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4912387
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2045 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TTFIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>9467607
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2050 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TFTIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>9467601
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2055 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TTRIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>34211329
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2010 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLTIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066484
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2015 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLFIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066498
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2020 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLWIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066480
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2025 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLQIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066486
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2030 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLHIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066495
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2035 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLYIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066477
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2040 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLZIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066474
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2045 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLXIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066478
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2050 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLLIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066492
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2055 Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TTIIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>34211326
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index Retirement Income Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRILX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066463
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Retirement Income Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLRIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>9467595
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Aggressive Growth Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSAIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508428
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Conservative Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCSIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508425
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Growth Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSGGX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508434
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Income Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSITX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508450
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Moderate Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSIMX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508443
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Managed Allocation Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIMIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530787
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Mid-Cap Growth Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRPWX
-              </para>
-            </entry>
-
-            <entry>
-              <para>297210
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Mid-Cap Value Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIMVX
-              </para>
-            </entry>
-
-            <entry>
-              <para>316178
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Money Market Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCIXX
-              </para>
-            </entry>
-
-            <entry>
-              <para>313650
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Real Estate Securities Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIREX
-              </para>
-            </entry>
-
-            <entry>
-              <para>303475
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF S&amp;P 500 Index Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TISPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>306658
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Short-Term Bond Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TISIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530784
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Small-Cap Blend Index Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TISBX
-              </para>
-            </entry>
-
-            <entry>
-              <para>309018
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Small-Cap Equity Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TISEX
-              </para>
-            </entry>
-
-            <entry>
-              <para>301622
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Social Choice Equity Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TISCX
-              </para>
-            </entry>
-
-            <entry>
-              <para>301897
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Tax-Exempt Bond Fund (Institutional)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TITIX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530819
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Bond Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIORX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530794
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Bond Index Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TBILX
-              </para>
-            </entry>
-
-            <entry>
-              <para>20739663
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Bond Plus Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCBPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530788
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Emerging Markets Equity Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TEMRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>26176542
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Emerging Markets Equity Index Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TEQKX
-              </para>
-            </entry>
-
-            <entry>
-              <para>26176545
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Equity Index Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TINRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530797
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Global Natural Resources Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TNRLX
-              </para>
-            </entry>
-
-            <entry>
-              <para>39444917
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Growth &amp; Income Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIIRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530790
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF High Yield Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIYRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530830
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Inflation-Linked Bond Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCILX
-              </para>
-            </entry>
-
-            <entry>
-              <para>313727
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF International Equity Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIERX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530827
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Large-Cap Growth Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIRTX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530791
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Large-Cap Value Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCLCX
-              </para>
-            </entry>
-
-            <entry>
-              <para>302696
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Retirement Income Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLRRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>9467600
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Aggressive Growth Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSALX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508429
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Conservative Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSCLX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508432
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Growth Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSGLX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508435
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Income Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSILX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508438
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Moderate Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSMLX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508453
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Managed Allocation Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIMRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530817
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Mid-Cap Growth Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCMGX
-              </para>
-            </entry>
-
-            <entry>
-              <para>305208
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Mid-Cap Value Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCMVX
-              </para>
-            </entry>
-
-            <entry>
-              <para>313995
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Money Market Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIRXX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530775
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Real Estate Securities Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCREX
-              </para>
-            </entry>
-
-            <entry>
-              <para>309567
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Short-Term Bond Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCTRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530822
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Small-Cap Equity Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCSEX
-              </para>
-            </entry>
-
-            <entry>
-              <para>297477
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Social Choice Equity Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TICRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530792
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Tax-Exempt Bond Fund (Retail)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIXRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>4530793
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Bond Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIDPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066506
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Bond Index Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TBIPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066534
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Bond Plus Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TBPPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066533
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Emerging Markets Equity Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TEMPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>26176541
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Emerging Markets Equity Index Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TEQPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>26176546
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Equity Index Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCEPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066530
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Global Natural Resources Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TNRPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>39444918
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Growth &amp; Income Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRPGX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066461
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF High Yield Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIHPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066501
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Inflation-Linked Bond Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TIKPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066500
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF International Equity Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TREPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066466
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF International Equity Index Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRIPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066462
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Large-Cap Growth Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TILPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066499
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Large-Cap Value Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRCPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066467
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2010 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCTPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066521
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2015 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCFPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066528
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2020 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCWPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066518
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2025 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCQPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066522
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2030 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCHPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066527
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2035 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCYPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066517
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2040 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCZPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066516
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2045 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TTFPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066444
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2050 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TCLPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066526
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle 2055 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TTRPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>34211331
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2010 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLTPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066483
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2015 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLFPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066497
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2020 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLWPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066434
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2025 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLVPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066481
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2030 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLHPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066494
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2035 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLYPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066476
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2040 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLPRX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066487
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2045 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLMPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066489
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2050 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLLPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066491
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index 2055 Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TTIPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>34211327
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Index Retirement Income Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLIPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066493
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifecycle Retirement Income Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TPILX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066470
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Aggressive Growth Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSAPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508430
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Conservative Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TLSPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508426
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Growth Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSGPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508436
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Income Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSIPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508451
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Lifestyle Moderate Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSMPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>40508456
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Mid-Cap Growth Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRGPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066464
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Mid-Cap Value Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRVPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066455
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Money Market Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TPPXX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066469
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Real Estate Securities Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRRPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066459
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Short-Term Bond Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSTPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066445
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Small-Cap Equity Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TSRPX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066446
-              </para>
-            </entry>
-          </row>
-
-          <row>
-            <entry>
-              <para>TIAA-CREF Social Choice Equity Fund (Premier)
-              </para>
-            </entry>
-
-            <entry>
-              <para>TRPSX
-              </para>
-            </entry>
-
-            <entry>
-              <para>21066460
-              </para>
-            </entry>
-          </row>
-        </tbody>
-      </tgroup>
-    </table>
-
-    <para>Source: Comments in
-      <ulink url="https://rt.cpan.org/Ticket/Attachment/1121440/589997/Tiaacref.pm.zip"/>
-    </para>
-  </sect1>
-  <sect1 id="fq-obsolete-sources">
-    <title>Obsolete Finance::Quote Sources</title>
-
-    <para>This section provides information about sources that used to be provided by <application>Finance::Quote</application>
-      but have already been removed or have been not functioning correctly.
-    </para>
-
-    <sect2 id="fq-obsolete-sources-single">
-      <title>Obsolete Quote Sources - Individual sources</title>
-
-      <table frame="topbot" id="gnc-tbl-fq-obsolete-individual-source">
-        <title>Obsolete individual sources for quotes</title>
-
-        <tgroup cols="3">
+  <sect1 id="fq-details-some-sources">
+    <title>Details of Some Finance::Quote Sources</title>
+    <sect2 id="fq-spec-yahoo">
+      <title>Yahoo Specifics</title>
+
+      <abstract>
+        <para>Yahoo has offered quotes from many exchanges and markets. Alphavatage will behave similar but
+          without delay. If you are not asking for US markets, you have to specify where to look. A
+          typical Yahoo symbol has the form {&lt;ISIN&gt;|&lt;ticker&gt;}&lt;market suffix&gt;.
+        </para>
+      </abstract>
+
+      <note>
+        <title>Dots in Ticker Symbols</title>
+
+        <para>Because Yahoo uses the dot <keycap>.</keycap> as separator for the market, dots in symbols like in
+          <quote>BT.A</quote> at the <ulink url="https://www.londonstockexchange.com">London Stock
+            Exchange</ulink> are replaced by dash <keycap>-</keycap> resulting in <quote>BT-A.L</quote>.
+        </para>
+      </note>
+
+      <table frame="topbot" id="gnc-tbl-fq-yahoo-exchange-codes">
+        <title>Yahoo Codes for Exchanges and Markets</title>
+
+        <tgroup cols="4">
           <thead>
             <row>
               <entry>
-                <para>&appname; Name
+                <para>Country
                 </para>
               </entry>
 
               <entry>
-                <para>Finance::Quote Name
+                <para>Market or Index
                 </para>
               </entry>
 
               <entry>
-                <para>URL, Notes
+                <para>Suffix
                 </para>
               </entry>
-            </row>
-          </thead>
 
-          <tbody valign='middle'>
-            <row>
               <entry>
-                <para>American International Assurance, HK
-                </para>
-              </entry>
-
-              <entry>
-                <para>aiahk
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.aia.com.hk"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>BAMOSZ funds, HU
-                </para>
-              </entry>
-
-              <entry>
-                <para>bamosz
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.bamosz.hu"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>BMO NesbittBurns, CA
-                </para>
-              </entry>
-
-              <entry>
-                <para>bmonesbittburns
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://bmonesbittburns.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Budapest Stock Exchange (BET), ex-BUX, HU
-                </para>
-              </entry>
-
-              <entry>
-                <para>bse or bet
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.bet.hu"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Citywire Funds, GB
-                </para>
-              </entry>
-
-              <entry>
-                <para>citywire
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://citywire.co.uk"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Cominvest Asset Management, ex-Adig, DE
-                </para>
-              </entry>
-
-              <entry>
-                <para>cominvest
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.cominvest-am.de"/>
-                </para>
-
-                <para>Obsolete, update: <ulink url="https://eggert.org/software/Comdirect.pm"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Equinox Unit Trusts, ZA
-                </para>
-              </entry>
-
-              <entry>
-                <para>za_unittrusts
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.equinox.co.za"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Fidelity Investments, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>fidelity_direct
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.fidelity.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Fidelity Fixed, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>fidelityfixed
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.fidelity.com/fixed-income-bonds/overview"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Finance Canada
-                </para>
-              </entry>
-
-              <entry>
-                <para>financecanada
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://finance.canada.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>First Trust Portfolios, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>ftportfolios_direct
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.ftportfolios.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Fund Library, CA
-                </para>
-              </entry>
-
-              <entry>
-                <para>fundlibrary
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.fundlibrary.com"/>
-                </para>
-
-                <para>This module uses an id that represents the mutual fund on
-                  <ulink url="https://www.fundlibrary.com"/>. There is no easy way of fetching the
-                  id except to jump onto the fundlibrary website, look up the fund and view the url
-                  for clues to its id number.
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>HElsinki stock eXchange, FI
-                </para>
-              </entry>
-
-              <entry>
-                <para>hex
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.hex.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Man Investments, AU
-                </para>
-              </entry>
-
-              <entry>
-                <para>maninv
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.maninvestments.com.au"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Morningstar, SE
-                </para>
-              </entry>
-
-              <entry>
-                <para>morningstar
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.morningstar.se"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Paris Stock Exchange/LeRevenu, FR
-                </para>
-              </entry>
-
-              <entry>
-                <para>lerevenu
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://bourse.lerevenu.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Platinum Asset Management, AU
-                </para>
-              </entry>
-
-              <entry>
-                <para>platinum
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.platinum.com.au"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>SIX Swiss Exchange Funds, CH
-                </para>
-              </entry>
-
-              <entry>
-                <para>sixfunds
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.six-swiss-exchange.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>SIX Swiss Exchange Shares, CH
-                </para>
-              </entry>
-
-              <entry>
-                <para>sixshares
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.six-swiss-exchange.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>StockHouse Canada, CA
-                </para>
-              </entry>
-
-              <entry>
-                <para>stockhousecanada_fund
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.stockhouse.ca"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>TD Waterhouse Funds, CA
-                </para>
-              </entry>
-
-              <entry>
-                <para>tdwaterhouse
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.tdassetmanagement.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>TD Efunds, CA
-                </para>
-              </entry>
-
-              <entry>
-                <para>tdefunds
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.tdwaterhouse.ca"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Trustnet via tnetuk.pm, GB
-                </para>
-              </entry>
-
-              <entry>
-                <para>tnetuk
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.trustnet.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Trustnet via trustnet.pm, GB
-                </para>
-              </entry>
-
-              <entry>
-                <para>trustnet
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.trustnet.com"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>US Treasury Bonds, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>usfedbonds
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="https://www.publicdebt.treas.gov"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Vanguard, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>vanguard
-                </para>
-              </entry>
-
-              <entry>
-                <para>part of AlphaVantage
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>VWD, DE (unmaintained)
-                </para>
-              </entry>
-
-              <entry>
-                <para>vwd
-                </para>
-              </entry>
-
-              <entry>
-                <para>See <ulink url="&url-mail-ar;gnucash-user/2008-February/023686.html"/>
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Yahoo USA
-                </para>
-
-                <para>Yahoo Asia
-                </para>
-
-                <para>Yahoo Australia
-                </para>
-
-                <para>Yahoo Brasil
-                </para>
-
-                <para>Yahoo Europe
-                </para>
-
-                <para>Yahoo New Zealand
-                </para>
-              </entry>
-
-              <entry>
-                <para>yahoo
-                </para>
-
-                <para>yahoo_asia
-                </para>
-
-                <para>yahoo_australia
-                </para>
-
-                <para>yahoo_brasil
-                </para>
-
-                <para>yahoo_europe
-                </para>
-
-                <para>yahoo_nz
-                </para>
-              </entry>
-
-              <entry>
-                <para>CSV interface since 2017-11-01 shut off
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Yahoo as YQL, US
-                </para>
-              </entry>
-
-              <entry>
-                <para>yahoo_yql
-                </para>
-              </entry>
-
-              <entry>
-                <para><ulink url="&url-yh-fin;"/> through "Yahoo Query Language"
-                </para>
-              </entry>
-            </row>
-
-            <row>
-              <entry>
-                <para>Zuerich Investments (replaced)
-                </para>
-              </entry>
-
-              <entry>
-                <para>zifunds
-                </para>
-              </entry>
-
-              <entry>
-                <para>Zürich Invest has been purchased by Deutsche Bank and integrated into DWS.
-                </para>
-              </entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </table>
-    </sect2>
-
-    <sect2 id="fq-obsolete-sources-multiple">
-      <title>Obsolete Finance::Quote Sources - Multiple sources</title>
-
-      <table frame="topbot" id="gnc-tbl-fq-obsolete-multiple-source">
-        <title>Obsolete Multiple sources for quotes</title>
-
-        <tgroup cols="1">
-          <thead>
-            <row>
-              <entry>
-                <para>Name
+                <para>Delay
                 </para>
               </entry>
             </row>
@@ -6922,56 +1875,5119 @@ bogus_symbol2,price2,date2
           <tbody>
             <row>
               <entry>
-                Asia disappeared with Yahoo
+                <para>Argentina
+                </para>
+              </entry>
+
+              <entry>
+                <para>Buenos Aires Stock Exchange (BYMA)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.BA
+                </para>
+              </entry>
+
+              <entry>
+                <para>30 min
+                </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                Brasil disappeared with Yahoo
+                <para>Australia
+                </para>
+              </entry>
+
+              <entry>
+                <para>Australian Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.AX
+                </para>
+              </entry>
+
+              <entry>
+                <para>20 min
+                </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                Fidelity (Fidelity, ...)
+                <para>Austria
+                </para>
+              </entry>
+
+              <entry>
+                <para>Vienna Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.VI
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                Finland (HEX, ...)
+                <para>Belgium
+                </para>
+              </entry>
+
+              <entry>
+                <para>Euronext Brussels
+                </para>
+              </entry>
+
+              <entry>
+                <para>.BR
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                First Trust (First Trust, ...)
+                <para>Brazil
+                </para>
+              </entry>
+
+              <entry>
+                <para>Sao Paolo Stock Exchange (BOVESPA)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.SA
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                Hungary (Bamosz, BET, ...)
+                <para>Canada
+                </para>
+              </entry>
+
+              <entry>
+                <para>Canadian Securities ExchangeToronto Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.CN
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                New Zealand (NZX, ...)
+                <para>Canada
+                </para>
+              </entry>
+
+              <entry>
+                <para>NEO Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.NE
+                </para>
+              </entry>
+
+              <entry>
+                <para>Real-time
+                </para>
               </entry>
             </row>
 
             <row>
               <entry>
-                U.K. Unit Trusts (trustnet, ...)
+                <para>Canada
+                </para>
+              </entry>
+
+              <entry>
+                <para>Toronto Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.TO
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
               </entry>
             </row>
 
+            <row>
+              <entry>
+                <para>Canada
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSX Venture Exchange (TSXV)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.V
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Chile
+                </para>
+              </entry>
+
+              <entry>
+                <para>Santiago Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.SN
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>China
+                </para>
+              </entry>
+
+              <entry>
+                <para>Shanghai Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.SS
+                </para>
+              </entry>
+
+              <entry>
+                <para>30 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>China
+                </para>
+              </entry>
+
+              <entry>
+                <para>Shenzhen Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.SZ
+                </para>
+              </entry>
+
+              <entry>
+                <para>30 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Czech Republic
+                </para>
+              </entry>
+
+              <entry>
+                <para>Prague Stock Exchange Index
+                </para>
+              </entry>
+
+              <entry>
+                <para>.PR
+                </para>
+              </entry>
+
+              <entry>
+                <para>20 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Denmark
+                </para>
+              </entry>
+
+              <entry>
+                <para>Nasdaq OMX Copenhagen
+                </para>
+              </entry>
+
+              <entry>
+                <para>.CO
+                </para>
+              </entry>
+
+              <entry>
+                <para>Real-time
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Egypt
+                </para>
+              </entry>
+
+              <entry>
+                <para>Egyptian Exchange Index (EGID)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.CA
+                </para>
+              </entry>
+
+              <entry>
+                <para>20 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Estonia
+                </para>
+              </entry>
+
+              <entry>
+                <para>Nasdaq OMX Tallinn
+                </para>
+              </entry>
+
+              <entry>
+                <para>.TL
+                </para>
+              </entry>
+
+              <entry>
+                <para>Real-time
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Finland
+                </para>
+              </entry>
+
+              <entry>
+                <para>Nasdaq OMX Helsinki
+                </para>
+              </entry>
+
+              <entry>
+                <para>.HE
+                </para>
+              </entry>
+
+              <entry>
+                <para>Real-time
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>France
+                </para>
+              </entry>
+
+              <entry>
+                <para>Euronext
+                </para>
+              </entry>
+
+              <entry>
+                <para>.NX
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>France
+                </para>
+              </entry>
+
+              <entry>
+                <para>Euronext Paris
+                </para>
+              </entry>
+
+              <entry>
+                <para>.PA
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Germany
+                </para>
+              </entry>
+
+              <entry>
+                <para>Berlin Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.BE
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Germany
+                </para>
+              </entry>
+
+              <entry>
+                <para>Bremen Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.BM
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Germany
+                </para>
+              </entry>
+
+              <entry>
+                <para>Dusseldorf Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.DU
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Germany
+                </para>
+              </entry>
+
+              <entry>
+                <para>Frankfurt Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.F
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Germany
+                </para>
+              </entry>
+
+              <entry>
+                <para>Hamburg Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.HM
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Germany
+                </para>
+              </entry>
+
+              <entry>
+                <para>Hanover Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.HA
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Germany
+                </para>
+              </entry>
+
+              <entry>
+                <para>Munich Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.MU
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Germany
+                </para>
+              </entry>
+
+              <entry>
+                <para>Stuttgart Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.SG
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Germany
+                </para>
+              </entry>
+
+              <entry>
+                <para>Deutsche Boerse XETRA
+                </para>
+              </entry>
+
+              <entry>
+                <para>.DE
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Global
+                </para>
+              </entry>
+
+              <entry>
+                <para>Currency Rates
+                </para>
+              </entry>
+
+              <entry>
+                <para>=X
+                </para>
+              </entry>
+
+              <entry>
+                <para>Real-time
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Greece
+                </para>
+              </entry>
+
+              <entry>
+                <para>Athens Stock Exchange (ATHEX)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.AT
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Hong Kong
+                </para>
+              </entry>
+
+              <entry>
+                <para>Hong Kong Stock Exchange (HKEX)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.HK
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min (Real-time in HK)
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Hungary
+                </para>
+              </entry>
+
+              <entry>
+                <para>Budapest Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.BD
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Iceland
+                </para>
+              </entry>
+
+              <entry>
+                <para>Nasdaq OMX Iceland
+                </para>
+              </entry>
+
+              <entry>
+                <para>.IC
+                </para>
+              </entry>
+
+              <entry>
+                <para>Real-time
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>India
+                </para>
+              </entry>
+
+              <entry>
+                <para>Bombay Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.BO
+                </para>
+              </entry>
+
+              <entry>
+                <para>Real-time
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>India
+                </para>
+              </entry>
+
+              <entry>
+                <para>National Stock Exchange of India
+                </para>
+              </entry>
+
+              <entry>
+                <para>.NS
+                </para>
+              </entry>
+
+              <entry>
+                <para>Real-time**
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Indonesia
+                </para>
+              </entry>
+
+              <entry>
+                <para>Indonesia Stock Exchange (IDX)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.JK
+                </para>
+              </entry>
+
+              <entry>
+                <para>10 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Ireland
+                </para>
+              </entry>
+
+              <entry>
+                <para>Euronext Dublin
+                </para>
+              </entry>
+
+              <entry>
+                <para>.IR
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Israel
+                </para>
+              </entry>
+
+              <entry>
+                <para>Tel Aviv Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.TA
+                </para>
+              </entry>
+
+              <entry>
+                <para>20 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Italy
+                </para>
+              </entry>
+
+              <entry>
+                <para>EuroTLX
+                </para>
+              </entry>
+
+              <entry>
+                <para>.TI
+                </para>
+              </entry>
+
+              <entry>
+                <para>20 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Italy
+                </para>
+              </entry>
+
+              <entry>
+                <para>Italian Stock Exchange, former Milano
+                </para>
+              </entry>
+
+              <entry>
+                <para>.MI
+                </para>
+              </entry>
+
+              <entry>
+                <para>20 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Japan
+                </para>
+              </entry>
+
+              <entry>
+                <para>Nikkei Indices
+                </para>
+              </entry>
+
+              <entry>
+                <para>N/A
+                </para>
+              </entry>
+
+              <entry>
+                <para>30 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Japan
+                </para>
+              </entry>
+
+              <entry>
+                <para>Tokyo Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.T
+                </para>
+              </entry>
+
+              <entry>
+                <para>20 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Latvia
+                </para>
+              </entry>
+
+              <entry>
+                <para>Nasdaq OMX Riga
+                </para>
+              </entry>
+
+              <entry>
+                <para>.RG
+                </para>
+              </entry>
+
+              <entry>
+                <para>Real-time
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Lithuania
+                </para>
+              </entry>
+
+              <entry>
+                <para>Nasdaq OMX Vilnius
+                </para>
+              </entry>
+
+              <entry>
+                <para>.VS
+                </para>
+              </entry>
+
+              <entry>
+                <para>Real-time
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Malaysia
+                </para>
+              </entry>
+
+              <entry>
+                <para>Malaysian Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.KL
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Mexico
+                </para>
+              </entry>
+
+              <entry>
+                <para>Mexico Stock Exchange (BMV)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.MX
+                </para>
+              </entry>
+
+              <entry>
+                <para>20 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Netherlands
+                </para>
+              </entry>
+
+              <entry>
+                <para>Euronext Amsterdam
+                </para>
+              </entry>
+
+              <entry>
+                <para>.AS
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>New Zealand
+                </para>
+              </entry>
+
+              <entry>
+                <para>New Zealand Stock Exchange (NZX)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.NZ
+                </para>
+              </entry>
+
+              <entry>
+                <para>20 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Norway
+                </para>
+              </entry>
+
+              <entry>
+                <para>Oslo Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.OL
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Portugal
+                </para>
+              </entry>
+
+              <entry>
+                <para>Euronext Lisbon
+                </para>
+              </entry>
+
+              <entry>
+                <para>.LS
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Qatar
+                </para>
+              </entry>
+
+              <entry>
+                <para>Qatar Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.QA
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Russia
+                </para>
+              </entry>
+
+              <entry>
+                <para>Moscow Exchange (MOEX)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.ME
+                </para>
+              </entry>
+
+              <entry>
+                <para>Real-time
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Singapore
+                </para>
+              </entry>
+
+              <entry>
+                <para>Singapore Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.SI
+                </para>
+              </entry>
+
+              <entry>
+                <para>20 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>South Africa
+                </para>
+              </entry>
+
+              <entry>
+                <para>Johannesburg Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.Jo
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>South Korea
+                </para>
+              </entry>
+
+              <entry>
+                <para>Korea Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.KS
+                </para>
+              </entry>
+
+              <entry>
+                <para>20 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>South Korea
+                </para>
+              </entry>
+
+              <entry>
+                <para>KOSDAQ
+                </para>
+              </entry>
+
+              <entry>
+                <para>.KQ
+                </para>
+              </entry>
+
+              <entry>
+                <para>20 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Spain
+                </para>
+              </entry>
+
+              <entry>
+                <para>Madrid SE C.A.T.S.
+                </para>
+              </entry>
+
+              <entry>
+                <para>.MC
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Saudi Arabia
+                </para>
+              </entry>
+
+              <entry>
+                <para>Saudi Stock Exchange (Tadawul)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.SAU
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Sweden
+                </para>
+              </entry>
+
+              <entry>
+                <para>Nasdaq OMX Stockholm
+                </para>
+              </entry>
+
+              <entry>
+                <para>.ST
+                </para>
+              </entry>
+
+              <entry>
+                <para>Real-time
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Switzerland
+                </para>
+              </entry>
+
+              <entry>
+                <para>Swiss Exchange (SIX)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.SW
+                </para>
+              </entry>
+
+              <entry>
+                <para>30 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Taiwan
+                </para>
+              </entry>
+
+              <entry>
+                <para>Taiwan OTC Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.TWO
+                </para>
+              </entry>
+
+              <entry>
+                <para>20 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Taiwan
+                </para>
+              </entry>
+
+              <entry>
+                <para>Taiwan Stock Exchange (TWSE)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.TW
+                </para>
+              </entry>
+
+              <entry>
+                <para>20 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Thailand
+                </para>
+              </entry>
+
+              <entry>
+                <para>Stock Exchange of Thailand (SET)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.BK
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Turkey
+                </para>
+              </entry>
+
+              <entry>
+                <para>Borsa İstanbul
+                </para>
+              </entry>
+
+              <entry>
+                <para>.IS
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>United Kingdom
+                </para>
+              </entry>
+
+              <entry>
+                <para>FTSE Indices
+                </para>
+              </entry>
+
+              <entry>
+                <para>N/A
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>United Kingdom
+                </para>
+              </entry>
+
+              <entry>
+                <para>London Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.L
+                </para>
+              </entry>
+
+              <entry>
+                <para>20 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>United Kingdom
+                </para>
+              </entry>
+
+              <entry>
+                <para>London Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.IL
+                </para>
+              </entry>
+
+              <entry>
+                <para>20 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>United States of America
+                </para>
+              </entry>
+
+              <entry>
+                <para>Chicago Board of Trade (CBOT)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.CBT
+                </para>
+              </entry>
+
+              <entry>
+                <para>10 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>United States of America
+                </para>
+              </entry>
+
+              <entry>
+                <para>Chicago Mercantile Exchange (CME)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.CME
+                </para>
+              </entry>
+
+              <entry>
+                <para>10 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>United States of America
+                </para>
+              </entry>
+
+              <entry>
+                <para>Dow Jones Indexes
+                </para>
+              </entry>
+
+              <entry>
+                <para>N/A
+                </para>
+              </entry>
+
+              <entry>
+                <para>Real-time
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>United States of America
+                </para>
+              </entry>
+
+              <entry>
+                <para>NASDAQ Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>N/A
+                </para>
+              </entry>
+
+              <entry>
+                <para>Real-time*
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>United States of America
+                </para>
+              </entry>
+
+              <entry>
+                <para>ICE Futures US, former New York Board of Trade
+                </para>
+              </entry>
+
+              <entry>
+                <para>.NYB
+                </para>
+              </entry>
+
+              <entry>
+                <para>30 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>United States of America
+                </para>
+              </entry>
+
+              <entry>
+                <para>New York Commodities Exchange (COMEX)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.CMX
+                </para>
+              </entry>
+
+              <entry>
+                <para>30 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>United States of America
+                </para>
+              </entry>
+
+              <entry>
+                <para>New York Mercantile Exchange (NYMEX)
+                </para>
+              </entry>
+
+              <entry>
+                <para>.NYM
+                </para>
+              </entry>
+
+              <entry>
+                <para>30 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>United States of America
+                </para>
+              </entry>
+
+              <entry>
+                <para>Options Price Reporting Authority (OPRA)
+                </para>
+              </entry>
+
+              <entry>
+                <para>N/A
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>United States of America
+                </para>
+              </entry>
+
+              <entry>
+                <para>OTC Bulletin Board Market
+                </para>
+              </entry>
+
+              <entry>
+                <para>N/A
+                </para>
+              </entry>
+
+              <entry>
+                <para>Real-time
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>United States of America
+                </para>
+              </entry>
+
+              <entry>
+                <para>OTC Markets Group
+                </para>
+              </entry>
+
+              <entry>
+                <para>N/A
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>United States of America
+                </para>
+              </entry>
+
+              <entry>
+                <para>S &amp; P Indices
+                </para>
+              </entry>
+
+              <entry>
+                <para>N/A
+                </para>
+              </entry>
+
+              <entry>
+                <para>Real-time
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>Venezuela
+                </para>
+              </entry>
+
+              <entry>
+                <para>Caracas Stock Exchange
+                </para>
+              </entry>
+
+              <entry>
+                <para>.CR
+                </para>
+              </entry>
+
+              <entry>
+                <para>15 min
+                </para>
+              </entry>
+            </row>
           </tbody>
         </tgroup>
       </table>
 
+      <para>Source: <ulink url="&url-yh-hlp;kb/SLN2310.html?redirect=true"/> queried at 2020-04-14.
+      </para>
+    </sect2>
+
+    <sect2 id="fq-spec-tiaa">
+      <title>TIAA-CREF Specifics</title>
+
+      <abstract>
+        <para>TIAA-CREF Annuities are not listed on any exchange, unlike their mutual funds TIAA-CREF provides
+          unit values via a cgi on their website. The cgi returns a csv file in the format
+          <programlisting language="csv">bogus_symbol1,price1,date1
+            bogus_symbol2,price2,date2
+            …</programlisting>
+          where <replaceable>bogus_symbol</replaceable> takes on the following values for the various
+          annuities:
+        </para>
+      </abstract>
+
+      <note>
+        <para>The symbols are case-sensitive and changed their capitalization in the last time.
+        </para>
+      </note>
+
+      <table frame="topbot" id="PsSymbs-TIAA-CREF">
+        <title>Pseudo-symbols that can be used for TIAA-CREF quotes</title>
+
+        <tgroup cols="3">
+          <colspec colnum="1"/>
+          <!-- yelp seems to ignore colnum -->
+          <colspec colnum="2"/>
+
+          <colspec colnum="3" align="right"/>
+
+          <thead>
+            <row>
+              <entry align="center">
+                <para>Name
+                </para>
+              </entry>
+
+              <entry align="center">
+                <para>Symbol
+                </para>
+              </entry>
+
+              <entry align="center">
+                <para>bogus
+                </para>
+              </entry>
+            </row>
+          </thead>
+
+          <tbody>
+            <row>
+              <entry>
+                <para>CREF Bond Market Account
+                </para>
+              </entry>
+
+              <entry>
+                <para>CREFbond
+                </para>
+              </entry>
+
+              <entry>
+                <para>41081991
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>CREF Equity Index Account
+                </para>
+              </entry>
+
+              <entry>
+                <para>CREFequi
+                </para>
+              </entry>
+
+              <entry>
+                <para>41082540
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>CREF Global Equities Account
+                </para>
+              </entry>
+
+              <entry>
+                <para>CREFglob
+                </para>
+              </entry>
+
+              <entry>
+                <para>41081992
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>CREF Growth Account
+                </para>
+              </entry>
+
+              <entry>
+                <para>CREFgrow
+                </para>
+              </entry>
+
+              <entry>
+                <para>41082544
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>CREF Inflation-Linked Bond Account
+                </para>
+              </entry>
+
+              <entry>
+                <para>CREFinfb
+                </para>
+              </entry>
+
+              <entry>
+                <para>41088773
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>CREF Money Market Account
+                </para>
+              </entry>
+
+              <entry>
+                <para>CREFmony
+                </para>
+              </entry>
+
+              <entry>
+                <para>41081993
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>CREF Social Choice Account
+                </para>
+              </entry>
+
+              <entry>
+                <para>CREFsoci
+                </para>
+              </entry>
+
+              <entry>
+                <para>41081994
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>CREF Stock Account
+                </para>
+              </entry>
+
+              <entry>
+                <para>CREFstok
+                </para>
+              </entry>
+
+              <entry>
+                <para>41081995
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA Real Estate Account
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIAAreal
+                </para>
+              </entry>
+
+              <entry>
+                <para>41091375
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Bond Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIDRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530828
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Bond Index Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TBIRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>20739662
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Bond Plus Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCBRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530816
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Emerging Markets Equity Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TEMSX
+                </para>
+              </entry>
+
+              <entry>
+                <para>26176543
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Emerging Markets Equity Index Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TEQSX
+                </para>
+              </entry>
+
+              <entry>
+                <para>26176547
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Equity Index Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIQRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530786
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Global Natural Resources Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TNRRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>39444919
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Growth &amp; Income Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRGIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>312536
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF High Yield Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIHRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530821
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Inflation-Linked Bond Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIKRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530829
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF International Equity Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRERX
+                </para>
+              </entry>
+
+              <entry>
+                <para>302323
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF International Equity Index Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRIEX
+                </para>
+              </entry>
+
+              <entry>
+                <para>300269
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Large-Cap Growth Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TILRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530785
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Large-Cap Growth Index Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRIRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>299525
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Large-Cap Value Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRLCX
+                </para>
+              </entry>
+
+              <entry>
+                <para>301332
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Large-Cap Value Index Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRCVX
+                </para>
+              </entry>
+
+              <entry>
+                <para>304333
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2010 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCLEX
+                </para>
+              </entry>
+
+              <entry>
+                <para>302817
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2015 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCLIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>302393
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2020 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCLTX
+                </para>
+              </entry>
+
+              <entry>
+                <para>307774
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2025 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCLFX
+                </para>
+              </entry>
+
+              <entry>
+                <para>313994
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2030 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCLNX
+                </para>
+              </entry>
+
+              <entry>
+                <para>307240
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2035 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCLRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>309003
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2040 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCLOX
+                </para>
+              </entry>
+
+              <entry>
+                <para>300959
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2045 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TTFRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>9467597
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2050 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLFRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>9467596
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2055 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TTRLX
+                </para>
+              </entry>
+
+              <entry>
+                <para>34211330
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2010 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLTRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066482
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2015 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLGRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066496
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2020 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLWRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066479
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2025 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLQRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066485
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2030 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLHRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066435
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2035 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLYRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066475
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2040 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLZRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066473
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2045 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLMRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066488
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2050 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLLRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066490
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2055 Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TTIRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>34211328
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index Retirement Income Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRCIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066468
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Retirement Income Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLIRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>9467594
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Aggressive Growth Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSARX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508431
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Conservative Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSCTX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508433
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Growth Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSGRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508437
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Income Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLSRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508427
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Moderate Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSMTX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508460
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Managed Allocation Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TITRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530825
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Mid-Cap Growth Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRGMX
+                </para>
+              </entry>
+
+              <entry>
+                <para>305499
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Mid-Cap Value Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRVRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>315272
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Money Market Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIEXX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530771
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Real Estate Securities Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRRSX
+                </para>
+              </entry>
+
+              <entry>
+                <para>300081
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF S&amp;P 500 Index Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRSPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>306105
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Short-Term Bond Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TISRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530818
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Small-Cap Blend Index Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRBIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>314644
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Small-Cap Equity Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRSEX
+                </para>
+              </entry>
+
+              <entry>
+                <para>299968
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Social Choice Equity Fund (Retirement)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRSCX
+                </para>
+              </entry>
+
+              <entry>
+                <para>300078
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Bond Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIBDX
+                </para>
+              </entry>
+
+              <entry>
+                <para>307276
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Bond Index Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TBIIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>20739664
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Bond Plus Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIBFX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530820
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Emerging Markets Equity Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TEMLX
+                </para>
+              </entry>
+
+              <entry>
+                <para>26176540
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Emerging Markets Equity Index Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TEQLX
+                </para>
+              </entry>
+
+              <entry>
+                <para>26176544
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Enhanced International Equity Index Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TFIIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>9467603
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Enhanced Large-Cap Growth Index Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLIIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>9467602
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Enhanced Large-Cap Value Index Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TEVIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>9467606
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Equity Index Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIEIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>301718
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Global Natural Resources Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TNRIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>39444916
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Growth &amp; Income Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIGRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>314719
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF High Yield Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIHYX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530798
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Inflation-Linked Bond Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIILX
+                </para>
+              </entry>
+
+              <entry>
+                <para>316693
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF International Equity Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIIEX
+                </para>
+              </entry>
+
+              <entry>
+                <para>305980
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF International Equity Index Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCIEX
+                </para>
+              </entry>
+
+              <entry>
+                <para>303673
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Large-Cap Growth Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TILGX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530800
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Large-Cap Growth Index Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TILIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>297809
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Large-Cap Value Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRLIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>300692
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Large-Cap Value Index Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TILVX
+                </para>
+              </entry>
+
+              <entry>
+                <para>302308
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2010 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCTIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4912376
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2015 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCNIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4912355
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2020 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCWIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4912377
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2025 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCYIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4912384
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2030 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCRIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4912364
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2035 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCIIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4912375
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2040 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCOIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4912387
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2045 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TTFIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>9467607
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2050 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TFTIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>9467601
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2055 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TTRIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>34211329
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2010 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLTIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066484
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2015 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLFIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066498
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2020 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLWIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066480
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2025 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLQIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066486
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2030 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLHIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066495
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2035 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLYIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066477
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2040 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLZIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066474
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2045 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLXIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066478
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2050 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLLIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066492
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2055 Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TTIIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>34211326
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index Retirement Income Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRILX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066463
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Retirement Income Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLRIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>9467595
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Aggressive Growth Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSAIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508428
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Conservative Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCSIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508425
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Growth Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSGGX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508434
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Income Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSITX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508450
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Moderate Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSIMX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508443
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Managed Allocation Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIMIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530787
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Mid-Cap Growth Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRPWX
+                </para>
+              </entry>
+
+              <entry>
+                <para>297210
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Mid-Cap Value Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIMVX
+                </para>
+              </entry>
+
+              <entry>
+                <para>316178
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Money Market Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCIXX
+                </para>
+              </entry>
+
+              <entry>
+                <para>313650
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Real Estate Securities Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIREX
+                </para>
+              </entry>
+
+              <entry>
+                <para>303475
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF S&amp;P 500 Index Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TISPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>306658
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Short-Term Bond Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TISIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530784
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Small-Cap Blend Index Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TISBX
+                </para>
+              </entry>
+
+              <entry>
+                <para>309018
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Small-Cap Equity Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TISEX
+                </para>
+              </entry>
+
+              <entry>
+                <para>301622
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Social Choice Equity Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TISCX
+                </para>
+              </entry>
+
+              <entry>
+                <para>301897
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Tax-Exempt Bond Fund (Institutional)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TITIX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530819
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Bond Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIORX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530794
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Bond Index Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TBILX
+                </para>
+              </entry>
+
+              <entry>
+                <para>20739663
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Bond Plus Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCBPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530788
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Emerging Markets Equity Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TEMRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>26176542
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Emerging Markets Equity Index Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TEQKX
+                </para>
+              </entry>
+
+              <entry>
+                <para>26176545
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Equity Index Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TINRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530797
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Global Natural Resources Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TNRLX
+                </para>
+              </entry>
+
+              <entry>
+                <para>39444917
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Growth &amp; Income Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIIRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530790
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF High Yield Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIYRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530830
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Inflation-Linked Bond Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCILX
+                </para>
+              </entry>
+
+              <entry>
+                <para>313727
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF International Equity Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIERX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530827
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Large-Cap Growth Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIRTX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530791
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Large-Cap Value Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCLCX
+                </para>
+              </entry>
+
+              <entry>
+                <para>302696
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Retirement Income Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLRRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>9467600
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Aggressive Growth Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSALX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508429
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Conservative Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSCLX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508432
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Growth Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSGLX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508435
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Income Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSILX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508438
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Moderate Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSMLX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508453
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Managed Allocation Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIMRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530817
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Mid-Cap Growth Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCMGX
+                </para>
+              </entry>
+
+              <entry>
+                <para>305208
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Mid-Cap Value Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCMVX
+                </para>
+              </entry>
+
+              <entry>
+                <para>313995
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Money Market Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIRXX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530775
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Real Estate Securities Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCREX
+                </para>
+              </entry>
+
+              <entry>
+                <para>309567
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Short-Term Bond Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCTRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530822
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Small-Cap Equity Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCSEX
+                </para>
+              </entry>
+
+              <entry>
+                <para>297477
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Social Choice Equity Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TICRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530792
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Tax-Exempt Bond Fund (Retail)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIXRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>4530793
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Bond Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIDPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066506
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Bond Index Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TBIPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066534
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Bond Plus Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TBPPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066533
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Emerging Markets Equity Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TEMPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>26176541
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Emerging Markets Equity Index Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TEQPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>26176546
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Equity Index Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCEPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066530
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Global Natural Resources Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TNRPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>39444918
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Growth &amp; Income Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRPGX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066461
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF High Yield Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIHPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066501
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Inflation-Linked Bond Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TIKPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066500
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF International Equity Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TREPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066466
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF International Equity Index Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRIPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066462
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Large-Cap Growth Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TILPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066499
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Large-Cap Value Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRCPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066467
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2010 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCTPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066521
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2015 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCFPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066528
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2020 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCWPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066518
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2025 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCQPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066522
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2030 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCHPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066527
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2035 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCYPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066517
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2040 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCZPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066516
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2045 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TTFPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066444
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2050 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TCLPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066526
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle 2055 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TTRPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>34211331
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2010 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLTPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066483
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2015 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLFPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066497
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2020 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLWPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066434
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2025 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLVPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066481
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2030 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLHPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066494
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2035 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLYPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066476
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2040 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLPRX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066487
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2045 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLMPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066489
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2050 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLLPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066491
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index 2055 Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TTIPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>34211327
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Index Retirement Income Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLIPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066493
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifecycle Retirement Income Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TPILX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066470
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Aggressive Growth Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSAPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508430
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Conservative Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TLSPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508426
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Growth Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSGPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508436
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Income Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSIPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508451
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Lifestyle Moderate Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSMPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>40508456
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Mid-Cap Growth Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRGPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066464
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Mid-Cap Value Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRVPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066455
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Money Market Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TPPXX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066469
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Real Estate Securities Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRRPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066459
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Short-Term Bond Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSTPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066445
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Small-Cap Equity Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TSRPX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066446
+                </para>
+              </entry>
+            </row>
+
+            <row>
+              <entry>
+                <para>TIAA-CREF Social Choice Equity Fund (Premier)
+                </para>
+              </entry>
+
+              <entry>
+                <para>TRPSX
+                </para>
+              </entry>
+
+              <entry>
+                <para>21066460
+                </para>
+              </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+
+      <para>Source: Comments in
+        <ulink url="https://rt.cpan.org/Ticket/Attachment/1121440/589997/Tiaacref.pm.zip"/>
+      </para>
     </sect2>
   </sect1>
 </appendix>

--- a/docbook/gnc-docbookx.dtd
+++ b/docbook/gnc-docbookx.dtd
@@ -166,6 +166,7 @@ https://www.w3.org/2003/entities/2007/w3centities-f.ent
 <!ENTITY url-ap-dev "https://developer.apple.com/">
 <!ENTITY url-cpan "https://www.cpan.org/">  <!-- Comprehensive Perl Archive Network -->
 <!ENTITY url-fints "https://www.hbci-zka.de/">
+<!ENTITY url-fq "https://github.com/finance-quote/finance-quote">
 <!ENTITY url-fsf "https://www.fsf.org/">
 <!ENTITY url-gh "https://github.com/"> <!-- we want to reference our libs, too.  -->
 <!ENTITY url-gh-we "&url-gh;Gnucash/"> <!-- Our project page -->
@@ -181,7 +182,7 @@ https://www.w3.org/2003/entities/2007/w3centities-f.ent
 <!ENTITY url-lw-de "https://linuxwiki.de/"> <!-- Append the desired topic -->
 <!ENTITY url-mysql "https://www.mysql.com/">
 <!ENTITY url-ofx "https://financialdataexchange.org//ofx"> <!-- Redirect of www.ofx.net -->
-<!ENTITY url-openhbci "https://openhbci.sourceforge.net/"> 
+<!ENTITY url-openhbci "https://openhbci.sourceforge.net/">
 <!ENTITY url-pgsql "https://www.postgresql.org/">
 <!ENTITY url-repo "https://repology.org/project/"> <!-- The packaging hub, append the desired project -->
 <!ENTITY url-saxon "https://saxon.sourceforge.net/"> <!-- XSLT and XQuery processor @ sourceforge -->
@@ -195,6 +196,7 @@ https://www.w3.org/2003/entities/2007/w3centities-f.ent
 <!-- Fixme: In April 2012, the XML project was retired
   For more information, please explore the Attic [http://attic.apache.org/]. -->
 <!ENTITY url-xalan "https://xml.apache.org/"> <!-- XSLT and XQuery processor @ apache -->
+<!ENTITY url-fq "https://github.com/finance-quote/finance-quote">
 <!ENTITY url-yh-fin "https://finance.yahoo.com/">  <!-- Append the desired topic -->
 <!ENTITY url-yh-hlp "https://help.yahoo.com/">  <!-- Append the desired topic -->
 


### PR DESCRIPTION
A few weeks ago @bpschuck [asked for help](https://github.com/finance-quote/finance-quote/discussions/423) with updating `Gnucash` for recent version of `finance-quote`. This is a complitentary PR to https://github.com/Gnucash/gnucash/pull/2033.

I decided to move modules that are not a part of the list into a new section for deprecated sources. IIUC this is still usefull information for a case when an old `.gnucash` file (or a database) has been configured with one of the deprecated sources.