### PR TITLE
manual:ch_Transactions: Define entities for colors used in the Import Matcher dialog box

### DIFF
--- a/C/manual/ch_Transactions.docbook
+++ b/C/manual/ch_Transactions.docbook
@@ -2496,32 +2496,25 @@ Translators:
                   </entry>
 
                   <entry>
-<?dbhtml bgcolor="#FFD700"?>
-<?dbfo bgcolor="#FFD700"?>
-                    Gold
+                    &color-intervention-probably-required; Gold
                   </entry>
 
                   <entry>
-<?dbhtml bgcolor="#FFD700"?>
-<?dbfo bgcolor="#FFD700"?>
-                    No matches, flagged for input and no transfer account matched &ndash; Import as
-                    a new transaction. Intervention required to select a transfer account.
+                    &color-intervention-probably-required; No matches, flagged for input and no
+                    transfer account matched &ndash; Import as a new transaction. Intervention
+                    required to select a transfer account.
                   </entry>
                 </row>
 
                 <row>
                   <entry>
-<?dbhtml bgcolor="#CFFFCB"?>
-<?dbfo bgcolor="#CFFFCB"?>
-                    DarkSeaGreen1
+                    &color-intervention-not-required; Green
                   </entry>
 
                   <entry>
-<?dbhtml bgcolor="#CFFFCB"?>
-<?dbfo bgcolor="#CFFFCB"?>
-                    No matches detected, flagged for input and a transfer account is matched &ndash;
-                    Import as a new transaction. Reconciliation status will be set as cleared (c) on
-                    import. Intervention is not required.
+                    &color-intervention-not-required; No matches detected, flagged for input and a
+                    transfer account is matched &ndash; Import as a new transaction. Reconciliation
+                    status will be set as cleared (c) on import. Intervention is not required.
                   </entry>
                 </row>
 
@@ -2531,17 +2524,13 @@ Translators:
                   </entry>
 
                   <entry>
-<?dbhtml bgcolor="#CFFFCB"?>
-<?dbfo bgcolor="#CFFFCB"?>
-                    DarkSeaGreen1
+                    &color-intervention-not-required; Green
                   </entry>
 
                   <entry>
-<?dbhtml bgcolor="#CFFFCB"?>
-<?dbfo bgcolor="#CFFFCB"?>
-                    Matches an existing transaction but not exactly on date and/or amount &ndash;
-                    Intervention not required, import and update. Reconciliation status will be set
-                    as cleared (c) on import.
+                    &color-intervention-not-required; Matches an existing transaction but not
+                    exactly on date and/or amount &ndash; Intervention not required, import and
+                    update. Reconciliation status will be set as cleared (c) on import.
                   </entry>
                 </row>
 
@@ -2551,17 +2540,13 @@ Translators:
                   </entry>
 
                   <entry>
-<?dbhtml bgcolor="#CFFFCB"?>
-<?dbfo bgcolor="#CFFFCB"?>
-                    DarkSeaGreen1
+                    &color-intervention-not-required; Green
                   </entry>
 
                   <entry>
-<?dbhtml bgcolor="#CFFFCB"?>
-<?dbfo bgcolor="#CFFFCB"?>
-                    Matches an existing transaction: &ndash; Not to be imported. The existing
-                    transaction reconciliation status will be as cleared (c) on import. Intervention
-                    is not required
+                    &color-intervention-not-required; Matches an existing transaction: &ndash; Not
+                    to be imported. The existing transaction reconciliation status will be as
+                    cleared (c) on import. Intervention is not required
                   </entry>
                 </row>
 
@@ -2569,16 +2554,12 @@ Translators:
                   <entry></entry>
 
                   <entry>
-<?dbhtml bgcolor="#FF4040"?>
-<?dbfo bgcolor="#FF4040"?>
-                    Brown1
+                    &color-intervention-required; Brown
                   </entry>
 
                   <entry>
-<?dbhtml bgcolor="#FF4040"?>
-<?dbfo bgcolor="#FF4040"?>
-                    Transaction has poor matches and no action was set: &ndash; Not to be imported.
-                    Intervention required.
+                    &color-intervention-required; Transaction has poor matches and no action was
+                    set: &ndash; Not to be imported. Intervention required.
                   </entry>
                 </row>
 
@@ -2586,15 +2567,11 @@ Translators:
                   <entry></entry>
 
                   <entry>
-<?dbhtml bgcolor="#6495ED"?>
-<?dbfo bgcolor="#6495ED"?>
-                    Cornflower Blue
+                    &color-row-selected; Blue
                   </entry>
 
                   <entry>
-<?dbhtml bgcolor="#6495ED"?>
-<?dbfo bgcolor="#6495ED"?>
-                    Row is selected
+                    &color-row-selected; Row is selected
                   </entry>
                 </row>
               </tbody>

--- a/C/manual/ch_Transactions.docbook
+++ b/C/manual/ch_Transactions.docbook
@@ -157,8 +157,8 @@ Translators:
       <para>The <guilabel>Currency Transfer</guilabel> pane is used to collect the needed information to enter
         the amount of the <guilabel>Transfer To</guilabel> split. You may enter either a price or an
         amount and <application>&appname;</application> will compute the other. If you have Online
-        Price Retrieval installed (see <xref linkend="fq-install"/>) you can use the
-        <guilabel>Fetch Rate</guilabel> button to retrieve a current quote.
+        Price Retrieval installed (see <xref linkend="fq-install"/>) you can use the <guilabel>Fetch
+        Rate</guilabel> button to retrieve a current quote.
       </para>
 
       <para>The <guilabel>Currency Transfer</guilabel> pane is enabled only if the selected accounts use
@@ -1746,12 +1746,14 @@ Translators:
                     <listitem>
                       <para>Once you have set all the import parameters, you can save these settings by typing a unique name in
                         the <guilabel>Load and Save Settings Entry</guilabel> combo box and clicking
-                        the Save icon <guiicon><inlinemediaobject>
-                        <imageobject>
-                          <imagedata fileref="figures/Icon_Save.png"
+                        the Save icon <guiicon>
+                        <inlinemediaobject>
+                          <imageobject>
+                            <imagedata fileref="figures/Icon_Save.png"
                                      srccredit="David Cousens"/>
-                        </imageobject>
-                      </inlinemediaobject></guiicon> just to the right of the box.
+                          </imageobject>
+                        </inlinemediaobject>
+                        </guiicon> just to the right of the box.
                       </para>
                     </listitem>
                   </varlistentry>
@@ -1771,13 +1773,15 @@ Translators:
                     <term>Delete</term>
 
                     <listitem>
-                      <para>The Delete/Trashcan icon <guiicon><inlinemediaobject>
-                        <imageobject>
-                          <imagedata fileref="figures/Icon_Delete.png"
+                      <para>The Delete/Trashcan icon <guiicon>
+                        <inlinemediaobject>
+                          <imageobject>
+                            <imagedata fileref="figures/Icon_Delete.png"
                                      srccredit="David Cousens"/>
-                        </imageobject>
-                      </inlinemediaobject></guiicon> to the right of the Save icon can be used to remove the saved settings
-                        group selected from the drop down list for the box.
+                          </imageobject>
+                        </inlinemediaobject>
+                        </guiicon> to the right of the Save icon can be used to remove the saved
+                        settings group selected from the drop down list for the box.
                       </para>
                     </listitem>
                   </varlistentry>
@@ -2716,10 +2720,7 @@ Translators:
         <title>Assign a Destination Account to a Single Transaction</title>
 
         <para>Select the required row by clicking <mousebutton>Button1</mousebutton> on it. It is displayed with a
-          <phrase>
-<?dbhtml bgcolor="#6495ED"?>
-<?dbfo bgcolor="#6495ED"?>
-          Cornflower Blue</phrase> background color.
+          <phrase>Blue</phrase> background color.
         </para>
 
         <para>Double clicking <mousebutton>Button1</mousebutton> on a row will select it and open an Account
@@ -2728,11 +2729,8 @@ Translators:
           <emphasis role="bold"><guibutton>OK</guibutton></emphasis>. The dialog has a
           <emphasis role="bold"><guibutton>New Account</guibutton></emphasis> button which will
           allow you to create a suitable account if there is no existing account which can be
-          applied as the transfer account.The row background will change to a <phrase>
-<?dbhtml bgcolor="#CFFFCB"?>
-<?dbfo bgcolor="#CFFFCB"?>
-          DarkSeaGreen1</phrase> and the assigned destination account will be displayed in the Info
-          column.
+          applied as the transfer account.The row background will change to a <phrase>Green</phrase>
+          and the assigned destination account will be displayed in the Info column.
         </para>
 
         <para>or alternatively, <mousebutton>Button1</mousebutton> click on a row to select it followed by a
@@ -2751,25 +2749,14 @@ Translators:
           the same destination account to all transactions in the selection.
         </para>
 
-        <para>Rows in a selection are displayed with a <phrase>
-<?dbhtml bgcolor="#6495ED"?>
-<?dbfo bgcolor="#6495ED"?>
-          Cornflower Blue</phrase> background.
+        <para>Rows in a selection are displayed with a <phrase>Blue</phrase> background.
         </para>
 
-        <para>Only rows which have the <emphasis role="strong">A</emphasis> checkbox checked and either a <phrase>
-<?dbhtml bgcolor="#CFFFCB"?>
-<?dbfo bgcolor="#CFFFCB"?>
-          DarkSeaGreen1</phrase> or <phrase>
-<?dbhtml bgcolor="#FFD700"?>
-<?dbfo bgcolor="#FFD700"?>
-          Gold</phrase> background colour can be selected for inclusion in a multiple selection.
-          Rows with a <phrase>
-<?dbhtml bgcolor="#FF4040"?>
-<?dbfo bgcolor="#FF4040"?>
-          Brown1</phrase> background or with the <emphasis role="strong">U+C</emphasis> or
-          <emphasis role="strong">C</emphasis> checkboxes checked cannot be selected in a multiple
-          selection.
+        <para>Only rows which have the <emphasis role="strong">A</emphasis> checkbox checked and either a
+          <phrase>Green</phrase> or <phrase>Gold</phrase> background colour can be selected for
+          inclusion in a multiple selection. Rows with a <phrase>Brown</phrase> background or with
+          the <emphasis role="strong">U+C</emphasis> or <emphasis role="strong">C</emphasis>
+          checkboxes checked cannot be selected in a multiple selection.
         </para>
 
         <para>To select rows and add rows to a selection either:

--- a/de/manual/ch_Transactions.docbook
+++ b/de/manual/ch_Transactions.docbook
@@ -2996,33 +2996,26 @@ Translators:
               </entry>
 
               <entry>
-<?dbhtml bgcolor="#FFD700"?>
-<?dbfo bgcolor="#FFD700"?>
-                gold
+                &color-intervention-probably-required; gold
               </entry>
 
               <entry>
-<?dbhtml bgcolor="#FFD700"?>
-<?dbfo bgcolor="#FFD700"?>
-                Keine Übereinstimmungen, zur Eingabe markiert und kein Gegenkonto zugeordnet
-                &ndash; Importieren als eine neue Buchung. Manueller Eingriff erforderlich, um ein
-                Überweisungskonto auszuwählen.
+                &color-intervention-probably-required; Keine Übereinstimmungen, zur Eingabe
+                markiert und kein Gegenkonto zugeordnet &ndash; Importieren als eine neue Buchung.
+                Manueller Eingriff erforderlich, um ein Überweisungskonto auszuwählen.
               </entry>
             </row>
 
             <row>
               <entry>
-<?dbhtml bgcolor="#CFFFCB"?>
-<?dbfo bgcolor="#CFFFCB"?>
-                dunkelgrün
+                &color-intervention-not-required; grün
               </entry>
 
               <entry>
-<?dbhtml bgcolor="#CFFFCB"?>
-<?dbfo bgcolor="#CFFFCB"?>
-                Keine Übereinstimmungen erkannt, zur Eingabe markiert und ein Übertragungskonto
-                wird zugeordnet &ndash; Importieren als neue Buchung. Der Abgleichungszustand wird
-                beim Import als bestätigt (b) markiert. Ein Eingreifen ist nicht erforderlich.
+                &color-intervention-not-required; Keine Übereinstimmungen erkannt, zur Eingabe
+                markiert und ein Übertragungskonto wird zugeordnet &ndash; Importieren als neue
+                Buchung. Der Abgleichungszustand wird beim Import als bestätigt (b) markiert. Ein
+                Eingreifen ist nicht erforderlich.
               </entry>
             </row>
 
@@ -3032,17 +3025,14 @@ Translators:
               </entry>
 
               <entry>
-<?dbhtml bgcolor="#CFFFCB"?>
-<?dbfo bgcolor="#CFFFCB"?>
-                dunkelgrün
+                &color-intervention-not-required; grün
               </entry>
 
               <entry>
-<?dbhtml bgcolor="#CFFFCB"?>
-<?dbfo bgcolor="#CFFFCB"?>
-                Passt zu einer vorhandenen Buchung, aber nicht genau hinsichtlich Datum und/oder
-                Betrag &ndash; Manueller Eingriff nicht erforderlich, importieren und aktualisieren.
-                Der Abgleichungszustand wird beim Import als bestätigt (b) markiert.
+                &color-intervention-not-required; Passt zu einer vorhandenen Buchung, aber nicht
+                genau hinsichtlich Datum und/oder Betrag &ndash; Manueller Eingriff nicht
+                erforderlich, importieren und aktualisieren. Der Abgleichungszustand wird beim
+                Import als bestätigt (b) markiert.
               </entry>
             </row>
 
@@ -3052,17 +3042,13 @@ Translators:
               </entry>
 
               <entry>
-<?dbhtml bgcolor="#CFFFCB"?>
-<?dbfo bgcolor="#CFFFCB"?>
-                dunkelgrün
+                &color-intervention-not-required; grün
               </entry>
 
               <entry>
-<?dbhtml bgcolor="#CFFFCB"?>
-<?dbfo bgcolor="#CFFFCB"?>
-                Entspricht einer bestehenden Buchung &ndash; Wird nicht importiert. Der
-                Abgleichungszustand der vorhandene Buchung wird beim Import als bestätigt (b)
-                angezeigt. Ein Eingreifen ist nicht erforderlich.
+                &color-intervention-not-required; Entspricht einer bestehenden Buchung &ndash; Wird
+                nicht importiert. Der Abgleichungszustand der vorhandene Buchung wird beim Import
+                als bestätigt (b) angezeigt. Ein Eingreifen ist nicht erforderlich.
               </entry>
             </row>
 
@@ -3070,16 +3056,13 @@ Translators:
               <entry></entry>
 
               <entry>
-<?dbhtml bgcolor="#FF4040"?>
-<?dbfo bgcolor="#FF4040"?>
-                braun
+                &color-intervention-required; braun
               </entry>
 
               <entry>
-<?dbhtml bgcolor="#FF4040"?>
-<?dbfo bgcolor="#FF4040"?>
-                Die Buchung hat eine schlechte Übereinstimmungen und es wurde keine Aktion gesetzt:
-                &ndash; Kann nicht importiert werden. Eine manuelle Handlung ist erforderlich.
+                &color-intervention-required; Die Buchung hat eine schlechte Übereinstimmungen und
+                es wurde keine Aktion gesetzt: &ndash; Kann nicht importiert werden. Eine manuelle
+                Handlung ist erforderlich.
               </entry>
             </row>
 
@@ -3087,15 +3070,11 @@ Translators:
               <entry></entry>
 
               <entry>
-<?dbhtml bgcolor="#6495ED"?>
-<?dbfo bgcolor="#6495ED"?>
-                kornblumenblau
+                &color-row-selected; blau
               </entry>
 
               <entry>
-<?dbhtml bgcolor="#6495ED"?>
-<?dbfo bgcolor="#6495ED"?>
-                Die Zeile ist ausgewählt.
+                &color-row-selected; Die Zeile ist ausgewählt.
               </entry>
             </row>
           </tbody>

--- a/de/manual/ch_Transactions.docbook
+++ b/de/manual/ch_Transactions.docbook
@@ -184,8 +184,8 @@ Translators:
         des Betrags des <guilabel>Buchen nach</guilabel> Buchungsteils zu erfassen. Sie können
         entweder einen Wechselkurs oder einen Betrag eingeben und &app; wird das andere berechnen.
         Wenn Sie den <emphasis>Online Kursabruf</emphasis> installiert haben (siehe
-        <xref linkend="fq-install"/>), können Sie über die Schaltfläche
-        <guilabel>Wechselkurs abrufen</guilabel> einen aktuellen Kurs abfragen.
+        <xref linkend="fq-install"/>), können Sie über die Schaltfläche <guilabel>Wechselkurs
+        abrufen</guilabel> einen aktuellen Kurs abfragen.
       </para>
 
       <para>Er ist nur aktiviert, wenn die ausgewählten Konten unterschiedliche Währungen verwenden oder der
@@ -3266,10 +3266,8 @@ Translators:
           <keycombo action="click">
             <mousebutton>Button1</mousebutton>
           </keycombo>
-          ausgewählt. Darauf hin wird sie mit einer <phrase>
-<?dbhtml bgcolor="#6495ED"?>
-<?dbfo bgcolor="#6495ED"?>
-          kornblumenblauen</phrase> Hintergrundfarbe angezeigt.
+          ausgewählt. Darauf hin wird sie mit einer <phrase>blauen</phrase> Hintergrundfarbe
+          angezeigt.
         </para>
 
         <para>Bei einem doppeltem Mausklick mit
@@ -3281,11 +3279,9 @@ Translators:
           Sie das gewünschte Konto im Dialog aus und klicken Sie auf <guibutton>OK</guibutton>. Der
           Dialog hat die Schaltfläche <guibutton>Neues Konto…</guibutton>, mit der Sie ein
           passendes Konto erstellen können, wenn es kein vorhandenes gibt, das als Gegenkonto
-          verwendet werden kann. Der Hintergrund der Zeile ändert sich zu <phrase>
-<?dbhtml bgcolor="#CFFFCB"?>
-<?dbfo bgcolor="#CFFFCB"?>
-          dunkelgrün</phrase> und das zugewiesene Konto wird in der Spalte <guilabel>zusätzliche
-          Kommentare</guilabel> angezeigt.
+          verwendet werden kann. Der Hintergrund der Zeile ändert sich zu <phrase>grün</phrase>
+          und das zugewiesene Konto wird in der Spalte <guilabel>zusätzliche Kommentare</guilabel>
+          angezeigt.
         </para>
 
         <para>Oder alternativ, ein Mausklick mit
@@ -3310,23 +3306,13 @@ Translators:
           Zielkontos auf alle markierten Buchungen.
         </para>
 
-        <para>Wenn Sie Zeilen in einer Auswahl erfassen, werden sie mit einem <phrase>
-<?dbhtml bgcolor="#6495ED"?>
-<?dbfo bgcolor="#6495ED"?>
-          kornblumenblauem</phrase> Hintergrund markiert.
+        <para>Wenn Sie Zeilen in einer Auswahl erfassen, werden sie mit einem <phrase>blauem</phrase> Hintergrund
+          markiert.
         </para>
 
         <para>Nur die Zeilen, in denen das Kontrollkästchen <guilabel>Neu</guilabel> aktiviert ist und die
-          entweder eine <phrase>
-<?dbhtml bgcolor="#CFFFCB"?>
-<?dbfo bgcolor="#CFFFCB"?>
-          dunkelgrüne</phrase> oder <phrase>
-<?dbhtml bgcolor="#FFD700"?>
-<?dbfo bgcolor="#FFD700"?>
-          goldene</phrase> Hintergrundfarbe haben, können in eine Mehrfachauswahl aufgenommen
-          werden. Zeilen mit einem <phrase>
-<?dbhtml bgcolor="#FF4040"?>
-<?dbfo bgcolor="#FF4040"?>
+          entweder eine <phrase>grüne</phrase> oder <phrase>goldene</phrase> Hintergrundfarbe
+          haben, können in eine Mehrfachauswahl aufgenommen werden. Zeilen mit einem <phrase>
           braunen</phrase> Hintergrund oder die bei <guilabel>Ü+Abgl</guilabel> oder
           <guilabel>Abgl</guilabel> angekreuzten sind können nicht in einer Mehrfachauswahl
           markiert werden.
@@ -3367,8 +3353,8 @@ Translators:
               <keycombo action="click">
                 <mousebutton>Button1</mousebutton>
               </keycombo>
-              <emphasis>gedrückt halten und über Zeilen ziehen können</emphasis>, um eine
-              Auswahl zu erstellen. Um weitere Zeilen hinzuzufügen, betätigen Sie
+              <emphasis>gedrückt halten und über Zeilen ziehen können</emphasis>, um eine Auswahl
+              zu erstellen. Um weitere Zeilen hinzuzufügen, betätigen Sie
               <keycombo>
                 &kc.ctrl;<mousebutton>Button1</mousebutton>
               </keycombo>

--- a/docbook/gnc-docbookx.dtd
+++ b/docbook/gnc-docbookx.dtd
@@ -96,6 +96,16 @@ https://www.w3.org/2003/entities/2007/w3centities-f.ent
 <!ENTITY img-w "800px">  <!-- The maximum width of the graphic elements. -->
 <!ENTITY dArrow "&lt;-|-&gt;"> <!-- double arrow: <-|->  -->
 
+<!--
+  Definition of some GUI colors
+  Import Matcher, amount of intervention required.
+  Use processing instructions to set the background color of table rows.
+-->
+ <!ENTITY color-intervention-required "<?dbhtml bgcolor='#FF4040' ?><?dbfo bgcolor='#FF4040' ?>"> <!-- color: Brown -->
+ <!ENTITY color-intervention-probably-required "<?dbhtml bgcolor='#FFD700' ?><?dbfo bgcolor='#FFD700' ?>"> <!-- color: Gold -->
+ <!ENTITY color-intervention-not-required "<?dbhtml bgcolor='#CFFFCB' ?><?dbfo bgcolor='#CFFFCB' ?>"> <!-- color: DarkSeaGreen -->
+ <!ENTITY color-row-selected "<?dbhtml bgcolor='#6495ED' ?><?dbfo bgcolor='#6495ED' ?>"> <!-- color: Cornflower Blue -->
+
 <!-- 
   5. Some common URLs - should be changed on demand.
   


### PR DESCRIPTION
Today, the color of table rows is set by "processing instructions". By using entities instead, it is easier to understand how the rows are colored.