### PR TITLE
cmake AddHtmlTarget: use config_file() for copying files

### DIFF
--- a/cmake/AddHtmlTarget.cmake
+++ b/cmake/AddHtmlTarget.cmake
@@ -11,21 +11,31 @@
 function (add_html_target targetbase lang entities figures xslt_file)
 
     set(docname "gnucash-${targetbase}")
-    set(styledir "${CMAKE_SOURCE_DIR}/stylesheet")
-    file(GLOB styleicons "${CMAKE_SOURCE_DIR}/stylesheet/*.png")
     set(BUILD_DIR "${DOCDIR_BUILD}/${lang}/${docname}")
 
     if (NOT IS_ABSOLUTE ${xslt_file})
         set(xslt_file "${CMAKE_CURRENT_SOURCE_DIR}/${xslt_file}")
     endif()
 
+    file(MAKE_DIRECTORY "${BUILD_DIR}" "${BUILD_DIR}/figures" "${BUILD_DIR}/stylesheet")
+
+    # Copy figures for this document
+    foreach(figure ${figures})
+        configure_file(${figure} ${BUILD_DIR}/figures COPYONLY)
+    endforeach()
+    file(GLOB dest_figures "${BUILD_DIR}/${figures}")
+
+    # Copy style icons for this document (warning, info, ...)
+    file(GLOB styleicons "${CMAKE_SOURCE_DIR}/stylesheet/*.png")
+    foreach(styleicon ${styleicons})
+        configure_file(${styleicon} ${BUILD_DIR}/stylesheet COPYONLY)
+    endforeach()
+    file(GLOB dest_styleicons "${BUILD_DIR}/stylesheet/*")
+
     # Convert xml to html with xsltproc
     # xsltproc --xinclude -o outputdir/ /usr/share/sgml/docbook/xsl-stylesheets/html/chunk.xsl filename.xml
     add_custom_command(
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/htmltrigger"
-      COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILD_DIR}"
-      COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILD_DIR}/figures"
-      COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILD_DIR}/stylesheet"
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/htmltrigger"
         COMMAND  ${XSLTPROC} ${XSLTPROCFLAGS} ${XSLTPROCFLAGS_HTML}
                              -o "${BUILD_DIR}/"
                              --param use.id.as.filename "1"
@@ -35,41 +45,14 @@ function (add_html_target targetbase lang entities figures xslt_file)
         COMMAND touch "${CMAKE_CURRENT_BINARY_DIR}/htmltrigger"
         DEPENDS ${entities} "index.docbook" "${CMAKE_SOURCE_DIR}/docbook/gnc-docbookx.dtd")
 
-    # Copy figures for this document
-    set(source_figures "")
-    foreach(figure ${figures})
-        list(APPEND source_figures "${CMAKE_CURRENT_SOURCE_DIR}/${figure}")
-    endforeach()
-
-    set(dest_figures "")
-    foreach(figure ${figures})
-        list(APPEND dest_figures "${BUILD_DIR}/${figure}")
-    endforeach()
-
-    if(dest_figures)
-        add_custom_command(
-            OUTPUT ${dest_figures}
-            COMMAND ${CMAKE_COMMAND} -E copy ${source_figures} "${BUILD_DIR}/figures"
-            COMMAND touch "${CMAKE_CURRENT_BINARY_DIR}/html_figtrigger"
-            DEPENDS ${source_figures} "${CMAKE_CURRENT_BINARY_DIR}/htmltrigger")
-    endif()
-
-    # Copy style icons for this document (warning, info,...)
-    add_custom_command(
-        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/styletrigger"
-        COMMAND  ${CMAKE_COMMAND} -E copy ${styleicons} "${BUILD_DIR}/stylesheet"
-        COMMAND touch "${CMAKE_CURRENT_BINARY_DIR}/styletrigger"
-        DEPENDS ${styleicons} "${CMAKE_CURRENT_BINARY_DIR}/htmltrigger")
-
     add_custom_target("${lang}-${targetbase}-html"
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/htmltrigger"
-                ${dest_figures}
-                "${CMAKE_CURRENT_BINARY_DIR}/styletrigger")
+                 ${dest_figures} ${dest_styleicons})
 
     add_dependencies(${lang}-html "${lang}-${targetbase}-html")
 
     if(WITH_HTML_INSTALL)
         install(DIRECTORY ${BUILD_DIR}
-          DESTINATION "${CMAKE_INSTALL_DOCDIR}/${lang}")
+            DESTINATION "${CMAKE_INSTALL_DOCDIR}/${lang}")
     endif()
 endfunction()


### PR DESCRIPTION
I took up some ideas from @usamimikamen-sk's #234 and, based on @gjanssens' comments, tried to make copying files as a “custom_command”.

I start the build with the command `cmake -G Ninja -S ../src -D CMAKE_INSTALL_PREFIX=..install -D WITH_HTML_INSTALL=ON`, which copies all files to the build directory for each languages.

However, I could not figure out how to control the dependency between build and the copying of the files during the installation of a single component, with e.g. `ninja de-html && ninja install de-html`.
All files are always copied, even for the languages that are not activated.
