### PR TITLE
Added some field detail to ch_invest.

### DIFF
--- a/C/guide/ch_invest.docbook
+++ b/C/guide/ch_invest.docbook
@@ -778,7 +778,7 @@ Income
                     stock ticker used in your quote source several lines down on the form.
                     <note>
                       <para>Different symbols will be used on different price sources for the same stock, an example is Ericsson
-                        on the Stockholm Exchange is ERIC-B while on Yahoo it is ERRICB.ST.
+                        on the Stockholm Exchange is ERIC-B while on Yahoo it is ERRICB.ST. Additionally, if the quote source requires the ISIN, CUSIP, or other code, it should be entered here.
                       </para>
                     </note>
                   </para>
@@ -795,6 +795,7 @@ Income
                 <listitem>
                   <para>The <guilabel>ISIN, CUSIP or other code</guilabel> is where you can enter some other coding number
                     or text (leave it blank in this example).
+                    This field is for user reference only and is <emphasis>not</emphasis> used by Finance::Quote.
                   </para>
                 </listitem>
 


### PR DESCRIPTION
Some clarification added to "Symbol/abbreviation" and "ISIN, CUSIP, or other code" fields.

See Finance::Quote issue [575](https://github.com/finance-quote/finance-quote/issues/575) for reference.

After closing the issue and explaining the user's error, the user subsequently opened a duplicate issue (instead of requesting the original issue be reopened) which I deleted and posted another followup message to the original issue. 

Hopefully the minor changes I made to `ch_invest.docbook` will minimize similar confusion in the future.